### PR TITLE
openssl: get and build the 1.1.1. branch

### DIFF
--- a/scripts/download_openssl.sh
+++ b/scripts/download_openssl.sh
@@ -4,5 +4,5 @@
 set -ex
 
 # Clone the repository to the specified directory.
-git clone --branch OpenSSL_1_0_2m https://github.com/openssl/openssl $1
+git clone --depth=1 --branch OpenSSL_1_0_2n https://github.com/openssl/openssl $1
 

--- a/scripts/install_openssl.sh
+++ b/scripts/install_openssl.sh
@@ -33,6 +33,6 @@ pushd ${SRCDIR}
          ${OPENSSLFLAGS}
 
 make
-make install
+make install_sw
 
 popd


### PR DESCRIPTION
The 1.0.2m branch doesn't exist anymore. Removed a few openssl config
options, out of which "enable-fuzz-libfuzzer" seemed to be necessary as
if I keep that openssl fails to build in my tests.