### PR TITLE
curl_fuzzer: use stricter timeout + server response timeout

### DIFF
--- a/curl_fuzzer.cc
+++ b/curl_fuzzer.cc
@@ -193,6 +193,7 @@ int fuzz_set_easy_options(FUZZ_DATA *fuzz)
 
   /* Time out requests quickly. */
   FTRY(curl_easy_setopt(fuzz->easy, CURLOPT_TIMEOUT_MS, 200L));
+  FTRY(curl_easy_setopt(fuzz->easy, CURLOPT_SERVER_RESPONSE_TIMEOUT, 1L));
 
   /* Can enable verbose mode by having the environment variable FUZZ_VERBOSE. */
   if(fuzz->verbose) {


### PR DESCRIPTION
Reduce the timeout to 60 seconds and since the timeout is no longer including
the disconnect phase, make use of "server response timeout" for that. Setting
that to 5 seconds.