### PR TITLE
i386: compile zlib into the fuzzer

### DIFF
--- a/ossfuzz.sh
+++ b/ossfuzz.sh
@@ -21,6 +21,7 @@ SCRIPTDIR=${BUILD_ROOT}/scripts
 
 . ${SCRIPTDIR}/fuzz_targets
 
+ZLIBDIR=/tmp/zlib
 OPENSSLDIR=/src/openssl
 NGHTTPDIR=/src/nghttp2
 
@@ -34,11 +35,11 @@ echo "FUZZ_TARGETS: $FUZZ_TARGETS"
 
 export MAKEFLAGS+="-j$(nproc)"
 
-# Check and install i386 libraries if necessary.
-${SCRIPTDIR}/check_i386.sh
-
 # Make an install directory
 export INSTALLDIR=/src/curl_install
+
+# Install zlib
+${SCRIPTDIR}/handle_x.sh zlib ${ZLIBDIR} ${INSTALLDIR} || exit 1
 
 # Install openssl
 export OPENSSLFLAGS="-fno-sanitize=alignment"

--- a/scripts/check_i386.sh
+++ b/scripts/check_i386.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ ${ARCHITECTURE} == "i386" ]]
-then
-    echo "Enabling i386 packages"
-    dpkg --add-architecture i386
-    apt-get update
-    apt-get install -y zlib1g-dev:i386
-fi

--- a/scripts/download_zlib.sh
+++ b/scripts/download_zlib.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# If any commands fail, fail the script immediately.
+set -ex
+
+wget https://www.zlib.net/zlib-1.2.11.tar.gz -O /tmp/zlib-1.2.11.tar.gz
+tar -xvf /tmp/zlib-1.2.11.tar.gz --directory /tmp
+
+# Copy the directory into the correct place
+mv -v /tmp/zlib-1.2.11 $1

--- a/scripts/install_zlib.sh
+++ b/scripts/install_zlib.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# If any commands fail, fail the script immediately.
+set -ex
+
+SRCDIR=$1
+INSTALLDIR=$2
+
+if [[ ! -d ${INSTALLDIR} ]]
+then
+  # Make an install target directory.
+  mkdir ${INSTALLDIR}
+fi
+
+pushd ${SRCDIR}
+
+./configure --prefix=${INSTALLDIR} \
+            --static
+
+make
+make install
+
+popd

--- a/scripts/ossfuzzdeps.sh
+++ b/scripts/ossfuzzdeps.sh
@@ -10,4 +10,5 @@ apt-get install -y make \
                    libtool \
                    libssl-dev \
                    zlib1g-dev \
-                   pkg-config
+                   pkg-config \
+                   wget


### PR DESCRIPTION
In i386 mode we need to compile zlib into the fuzzer.