### PR TITLE
add use of dns over https (doh)

### DIFF
--- a/curl_fuzzer.h
+++ b/curl_fuzzer.h
@@ -66,6 +66,7 @@
 #define TLV_TYPE_RTSP_CLIENT_CSEQ       38
 #define TLV_TYPE_MAIL_AUTH              39
 #define TLV_TYPE_HTTP_VERSION           40
+#define TLV_TYPE_DOH_URL                41
 
 /**
  * TLV function return codes.

--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -183,6 +183,7 @@ int fuzz_parse_tlv(FUZZ_DATA *fuzz, TLV *tlv)
     /* Define a set of singleton TLVs - they can only have their value set once
        and all follow the same pattern. */
     FSINGLETONTLV(fuzz, TLV_TYPE_URL, CURLOPT_URL);
+    FSINGLETONTLV(fuzz, TLV_TYPE_DOH_URL, CURLOPT_DOH_URL);
     FSINGLETONTLV(fuzz, TLV_TYPE_USERNAME, CURLOPT_USERNAME);
     FSINGLETONTLV(fuzz, TLV_TYPE_PASSWORD, CURLOPT_PASSWORD);
     FSINGLETONTLV(fuzz, TLV_TYPE_COOKIE, CURLOPT_COOKIE);


### PR DESCRIPTION
I managed to get the functions in doh.c exercised with this branch. It would be nice to see oss-fuzz cover also that function.

If you merge soon, it will be interesting to see if oss-fuzz finds the bug in https://github.com/curl/curl/pull/4352 before it has been merged into master. It may be difficult to randomly come up with a 480 something input while also matching the TLV and length, but let's see!
