### PR TITLE
bump the nghttp2 buld: latest version and build it lib-only

### DIFF
--- a/scripts/download_nghttp2.sh
+++ b/scripts/download_nghttp2.sh
@@ -4,5 +4,4 @@
 set -ex
 
 # Clone the repository to the specified directory.
-git clone --branch v1.33.0 https://github.com/nghttp2/nghttp2 $1
-
+git clone --branch v1.41.0 https://github.com/nghttp2/nghttp2 $1

--- a/scripts/install_nghttp2.sh
+++ b/scripts/install_nghttp2.sh
@@ -19,7 +19,7 @@ autoreconf -i
 ./configure --prefix=${INSTALLDIR} \
             --disable-shared \
             --enable-static \
-            --disable-threads
+            --disable-threads --enable-lib-only
 
 make
 make install


### PR DESCRIPTION
I want to avoid this bug (https://github.com/curl/curl/pull/5643#issuecomment-653565970) that possibly exists in that older nghttp2 version.