### PR TITLE
scripts/install_openssl.sh: install software only

### DIFF
--- a/scripts/install_openssl.sh
+++ b/scripts/install_openssl.sh
@@ -53,6 +53,6 @@ ${ARCH_PROG} ./config --prefix=${INSTALLDIR} \
                       ${OPENSSLFLAGS}
 
 make
-make install
+make install_sw
 
 popd


### PR DESCRIPTION
The installation of the docs is surprisingly slow, so by skipping those - that
aren't used anyway - this operation runs much faster.