### PR TITLE
solve download_zlib failure

### DIFF
--- a/scripts/download_zlib.sh
+++ b/scripts/download_zlib.sh
@@ -3,7 +3,10 @@
 # If any commands fail, fail the script immediately.
 set -ex
 
-wget https://www.zlib.net/zlib-1.2.11.tar.gz -O /tmp/zlib-1.2.11.tar.gz
+# Seems that https://www.zlib.net/zlib-1.2.11.tar.gz is now behind a proxy and
+# wget downloads an HTML page instead of the archive.
+# As a workaround, download this same archive (same hash) from the LIBPNG mirror
+wget https://kumisystems.dl.sourceforge.net/project/libpng/zlib/1.2.11/zlib-1.2.11.tar.gz -O /tmp/zlib-1.2.11.tar.gz
 tar -xvf /tmp/zlib-1.2.11.tar.gz --directory /tmp
 
 # Copy the directory into the correct place


### PR DESCRIPTION
Hi,
I was trying to compile curl-fuzzer in [fuzzbench](https://github.com/google/fuzzbench/tree/master/benchmarks/curl_curl_fuzzer_http) and the build failed when trying to unpack the zlib archive.
This is due to a recent update of zlib.net that now seems behind a proxy or something similar.
When downloading zlib with wget, it downloads an HTML page instead of the archive.
To fix this problem, now the exact same archive (same MD5) is downloaded from the mirror provided by LIBPNG.