### PR TITLE
fuzzer: Set a maximum write length for the fuzzer

### DIFF
--- a/curl_fuzzer.h
+++ b/curl_fuzzer.h
@@ -78,6 +78,9 @@
 /* Temporary write array size */
 #define TEMP_WRITE_ARRAY_SIZE           10
 
+/* Maximum write size in bytes to stop unbounded writes (50MB) */
+#define MAXIMUM_WRITE_LENGTH            52428800
+
 /* Cookie-jar path. */
 #define FUZZ_COOKIE_JAR_PATH            "/dev/null"
 
@@ -179,6 +182,9 @@ typedef struct fuzz_data
 
   /* Temporary writefunction state */
   char write_array[TEMP_WRITE_ARRAY_SIZE];
+
+  /* Cumulative length of "written" data */
+  size_t written_data;
 
   /* Upload data and length; */
   const uint8_t *upload1_data;

--- a/curl_fuzzer_callback.cc
+++ b/curl_fuzzer_callback.cc
@@ -222,5 +222,16 @@ size_t fuzz_write_callback(void *contents,
      exercised. */
   memcpy(fuzz->write_array, contents, copy_len);
 
+  /* Add on the total to the count. If it exceeds the maximum then return
+     zero to the caller so that the transfer is terminated early. */
+  fuzz->written_data += total;
+
+  if(fuzz->written_data > MAXIMUM_WRITE_LENGTH) {
+    FV_PRINTF(fuzz,
+              "FUZZ: Exceeded maximum write length (%lu) \n",
+              fuzz->written_data);
+    total = 0;
+  }
+
   return total;
 }


### PR DESCRIPTION
This prevents certain highly compressed payloads from timing out the fuzzer.