### PR TITLE
Replace Apache license with curl license.

### DIFF
--- a/ossfuzz.sh
+++ b/ossfuzz.sh
@@ -1,19 +1,25 @@
 #!/bin/bash -eu
-# Copyright 2016 Google Inc.
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# Copyright (C) 2018-2021, Max Dymond, <cmeister2@gmail.com>, et al.
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.haxx.se/docs/copyright.html.
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
 #
-################################################################################
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+###########################################################################
 
 # Save off the current folder as the build root.
 export BUILD_ROOT=$PWD


### PR DESCRIPTION
The Apache license was mistakenly applied to this file. Replace it with the standard curl
license header.

Closes #49

Signed-off-by: Max Dymond <cmeister2@gmail.com>