### PR TITLE
scripts/download_nghttp2.sh: clone 1.58.0

### DIFF
--- a/scripts/download_nghttp2.sh
+++ b/scripts/download_nghttp2.sh
@@ -4,4 +4,4 @@
 set -ex
 
 # Clone the repository to the specified directory.
-git clone --branch v1.41.0 https://github.com/nghttp2/nghttp2 $1
+git clone --branch v1.58.0 https://github.com/nghttp2/nghttp2 $1


### PR DESCRIPTION
Working on https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44517
that triggers an issue in nghttp2 we want to make sure it isn't due to a
problem in an old release.