### PR TITLE
download_zlib.sh: use 1.2.13 now

### DIFF
--- a/scripts/download_zlib.sh
+++ b/scripts/download_zlib.sh
@@ -3,8 +3,8 @@
 # If any commands fail, fail the script immediately.
 set -ex
 
-wget https://www.zlib.net/zlib-1.2.12.tar.gz -O /tmp/zlib-1.2.12.tar.gz
-tar -xvf /tmp/zlib-1.2.12.tar.gz --directory /tmp
+wget https://www.zlib.net/fossils/zlib-1.2.13.tar.gz -O /tmp/zlib-1.2.13.tar.gz
+tar -xvf /tmp/zlib-1.2.13.tar.gz --directory /tmp
 
 # Copy the directory into the correct place
-mv -v /tmp/zlib-1.2.12 $1
+mv -v /tmp/zlib-1.2.13 $1


### PR DESCRIPTION
The 1.2.12 tarball has been removed! This is the second time this has happened (see 543b9926cc32, "download_zlib.sh: use 1.2.12 now"), so change the URL to a (hopefully) more permanent source.