### PR TITLE
scripts: Fix openssl build in i386 mode

### DIFF
--- a/scripts/install_openssl.sh
+++ b/scripts/install_openssl.sh
@@ -16,7 +16,9 @@ fi
 if [[ ${ARCHITECTURE} == "i386" ]]
 then
     ARCH_PROG="setarch i386"
-    EC_FLAG=""
+
+    # Disabled as per https://github.com/google/oss-fuzz/blob/master/projects/openssl/build.sh
+    EC_FLAG="no-threads"
 else
     ARCH_PROG=""
     EC_FLAG="enable-ec_nistp_64_gcc_128"


### PR DESCRIPTION
Use the `no-threads` option like the oss-fuzz version of OpenSSL