### PR TITLE
ci: keep unaffected fuzzers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         oss-fuzz-project-name: 'curl'
         dry-run: false
+        keep-unaffected-fuzz-targets: true
 
     # Archive the fuzzer output (which maintains permissions)
     - name: Create fuzz tar


### PR DESCRIPTION
Need to keep unaffected fuzzers as the parallel step expects them all to exist.