### PR TITLE
tlv: do not leak on allocation failure in curl_slist_append

### DIFF
--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -270,6 +270,9 @@ void fuzz_setup_http_post(FUZZ_DATA *fuzz, TLV *tlv)
     struct curl_httppost *last = NULL;
 
     fuzz->post_body = fuzz_tlv_to_string(tlv);
+    if (fuzz->post_body == NULL) {
+      return;
+    }
 
     /* This is just one of several possible entrypoints to
      * the HTTPPOST API. see https://curl.se/libcurl/c/curl_formadd.html

--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -144,9 +144,12 @@ int fuzz_parse_tlv(FUZZ_DATA *fuzz, TLV *tlv)
       }
 
       tmp = fuzz_tlv_to_string(tlv);
+      if (tmp == NULL) {
+        // keep on despite allocation failure
+        break;
+      }
       new_list = curl_slist_append(fuzz->header_list, tmp);
       if (new_list == NULL) {
-        // keep on despite allocation failure
         break;
       }
       fuzz->header_list = new_list;
@@ -155,6 +158,10 @@ int fuzz_parse_tlv(FUZZ_DATA *fuzz, TLV *tlv)
 
     case TLV_TYPE_MAIL_RECIPIENT:
       tmp = fuzz_tlv_to_string(tlv);
+      if (tmp == NULL) {
+        // keep on despite allocation failure
+        break;
+      }
       new_list = curl_slist_append(fuzz->mail_recipients_list, tmp);
       if (new_list != NULL) {
         fuzz->mail_recipients_list = new_list;

--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -100,6 +100,7 @@ int fuzz_parse_tlv(FUZZ_DATA *fuzz, TLV *tlv)
   int rc;
   char *tmp = NULL;
   uint32_t tmp_u32;
+  curl_slist *new_list;
 
   switch(tlv->type) {
     /* The pointers in response TLVs will always be valid as long as the fuzz
@@ -143,14 +144,21 @@ int fuzz_parse_tlv(FUZZ_DATA *fuzz, TLV *tlv)
       }
 
       tmp = fuzz_tlv_to_string(tlv);
-      fuzz->header_list = curl_slist_append(fuzz->header_list, tmp);
+      new_list = curl_slist_append(fuzz->header_list, tmp);
+      if (new_list == NULL) {
+        // keep on despite allocation failure
+        break;
+      }
+      fuzz->header_list = new_list;
       fuzz->header_list_count++;
       break;
 
     case TLV_TYPE_MAIL_RECIPIENT:
       tmp = fuzz_tlv_to_string(tlv);
-      fuzz->mail_recipients_list =
-                            curl_slist_append(fuzz->mail_recipients_list, tmp);
+      new_list = curl_slist_append(fuzz->mail_recipients_list, tmp);
+      if (new_list != NULL) {
+        fuzz->mail_recipients_list = new_list;
+      }
       break;
 
     case TLV_TYPE_MIME_PART:


### PR DESCRIPTION
`curl_slist_append` can return NULL, especially when there is an allocation failure inside it...
In this case, ignore the addition of the new value (another option would be to go to `EXIT_LABEL` with some `rc` value for an error code)

This was found by POC nallocfuzz...