### PR TITLE
ossfuzz: Prevent large numbers of recipients from causing timeouts

### DIFF
--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -157,6 +157,12 @@ int fuzz_parse_tlv(FUZZ_DATA *fuzz, TLV *tlv)
       break;
 
     case TLV_TYPE_MAIL_RECIPIENT:
+      /* Limit the number of headers that can be added to a message to prevent
+         timeouts. */
+      if(fuzz->header_list_count >= TLV_MAX_NUM_CURLOPT_HEADER) {
+        rc = 255;
+        goto EXIT_LABEL;
+      }
       tmp = fuzz_tlv_to_string(tlv);
       if (tmp == NULL) {
         // keep on despite allocation failure


### PR DESCRIPTION
As in commit e13aa01d58a1b082f7bcb8ef07245decac35b193

Found by quadfuzz