### PR TITLE
ossfuzz: Prevent large numbers of headers from causing timeouts

### DIFF
--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -171,6 +171,7 @@ int fuzz_parse_tlv(FUZZ_DATA *fuzz, TLV *tlv)
       new_list = curl_slist_append(fuzz->mail_recipients_list, tmp);
       if (new_list != NULL) {
         fuzz->mail_recipients_list = new_list;
+        fuzz->header_list_count++;
       }
       break;
 


### PR DESCRIPTION
Compeltes previous commit

@bagder we went too fast with previous PR #75 ;-)