### PR TITLE
scripts: fix ssl builds on x86_64

### DIFF
--- a/scripts/install_openssl.sh
+++ b/scripts/install_openssl.sh
@@ -37,6 +37,7 @@ pushd ${SRCDIR}
 
 # Build the library.
 ${ARCH_PROG} ./config --prefix=${INSTALLDIR} \
+                      --libdir=lib \
                       --debug \
                       enable-fuzz-libfuzzer \
                       --with-fuzzer-lib=/usr/lib/libFuzzingEngine \


### PR DESCRIPTION
libssl.a is installed on `$PREFIX/lib64/` on x86_64 builds, and the scripts here are not aware of this location. Always use `$PREFIX/lib/` to keep things uniform.