### PR TITLE
Temporarily revert artifact snippets @4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     # Upload the fuzzer output
     - name: Archive fuzz tar
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: fuzz_tar
         path: fuzz.tar
@@ -66,7 +66,7 @@ jobs:
           - curl_fuzzer
           - fuzz_url
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: fuzz_tar
       - name: Unpack fuzzer ${{ matrix.fuzzer }}
@@ -80,7 +80,7 @@ jobs:
           fuzz-seconds: 120
           dry-run: false
       - name: Upload Crash
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: artifacts


### PR DESCRIPTION
The new v4 artifact snippets are flaky. See https://github.com/actions/download-artifact/issues/249.

Reverting until stable.