### PR TITLE
scripts/install_curl.sh: explicitly disable use of libpsl

### DIFF
--- a/scripts/install_curl.sh
+++ b/scripts/install_curl.sh
@@ -54,6 +54,7 @@ pushd ${SRCDIR}
             --disable-symbol-hiding \
             --enable-ipv6 \
             --enable-websockets \
+            --without-libpsl \
             --with-random=/dev/null \
             ${SSLOPTION} \
             ${NGHTTPOPTION} \


### PR DESCRIPTION
It will soon cause a configure error if not found when not explicitly disabled.