### PR TITLE
Resolve i386 build warnings and errors

### DIFF
--- a/curl_fuzzer_callback.cc
+++ b/curl_fuzzer_callback.cc
@@ -228,7 +228,7 @@ size_t fuzz_write_callback(void *contents,
 
   if(fuzz->written_data > MAXIMUM_WRITE_LENGTH) {
     FV_PRINTF(fuzz,
-              "FUZZ: Exceeded maximum write length (%lu) \n",
+              "FUZZ: Exceeded maximum write length (%zu) \n",
               fuzz->written_data);
     total = 0;
   }

--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -80,8 +80,8 @@ int fuzz_get_tlv_comn(FUZZ_DATA *fuzz,
   check_length += tlv->length;
 
   uint64_t remaining_len = fuzz->state.data_len;
-  FV_PRINTF(fuzz, "Check length of data: %lu \n", check_length);
-  FV_PRINTF(fuzz, "Remaining length of data: %lu \n", remaining_len);
+  FV_PRINTF(fuzz, "Check length of data: %" PRIu64 " \n", check_length);
+  FV_PRINTF(fuzz, "Remaining length of data: %" PRIu64 " \n", remaining_len);
 
   /* Sanity check that the TLV length is ok. */
   if(check_length > remaining_len) {

--- a/fuzz_bufq.cc
+++ b/fuzz_bufq.cc
@@ -195,8 +195,8 @@ int fuzz_handle_bufq(FuzzedDataProvider *fuzz)
       }
 
       case OP_TYPE_PEEK_AT: {
-        uint32_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
-        FV_PRINTF(verbose, "OP: peek at %u\n", op_size);
+        size_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
+        FV_PRINTF(verbose, "OP: peek at %zu\n", op_size);
         const unsigned char *pbuf;
         size_t plen;
         bool avail = Curl_bufq_peek_at(&q, op_size, &pbuf, &plen);
@@ -210,8 +210,8 @@ int fuzz_handle_bufq(FuzzedDataProvider *fuzz)
       }
 
       case OP_TYPE_READ: {
-        uint32_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
-        FV_PRINTF(verbose, "OP: read, size %u\n", op_size);
+        size_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
+        FV_PRINTF(verbose, "OP: read, size %zu\n", op_size);
         unsigned char *buf = (unsigned char *)malloc(op_size * sizeof(*buf));
         ssize_t read = Curl_bufq_read(&q, buf, op_size, &err);
         if (read != -1) {
@@ -229,8 +229,8 @@ int fuzz_handle_bufq(FuzzedDataProvider *fuzz)
       }
 
       case OP_TYPE_SLURP: {
-        uint32_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
-        FV_PRINTF(verbose, "OP: slurp, size %u\n", op_size);
+        ssize_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
+        FV_PRINTF(verbose, "OP: slurp, size %zd\n", op_size);
         struct reader_cb_ctx ctx = { .verbose = verbose, .template_buf = template_buf, .write_len = op_size, .next_byte_write = next_byte_write };
         ssize_t write = Curl_bufq_slurp(&q, bufq_reader_cb, &ctx, &err);
         if (write != -1) {
@@ -247,8 +247,8 @@ int fuzz_handle_bufq(FuzzedDataProvider *fuzz)
       }
 
       case OP_TYPE_SIPN: {
-        uint32_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
-        FV_PRINTF(verbose, "OP: sipn, size %u\n", op_size);
+        ssize_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
+        FV_PRINTF(verbose, "OP: sipn, size %zd\n", op_size);
         struct reader_cb_ctx ctx = { .verbose = verbose, .template_buf = template_buf, .write_len = op_size, .next_byte_write = next_byte_write };
         ssize_t write = Curl_bufq_sipn(&q, op_size, bufq_reader_cb, &ctx, &err);
         if (write != -1) {
@@ -263,8 +263,8 @@ int fuzz_handle_bufq(FuzzedDataProvider *fuzz)
       }
 
       case OP_TYPE_PASS: {
-        uint32_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
-        FV_PRINTF(verbose, "OP: pass, size %u\n", op_size);
+        ssize_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
+        FV_PRINTF(verbose, "OP: pass, size %zd\n", op_size);
         struct writer_cb_ctx ctx = { .verbose = verbose, .template_buf = template_buf, .read_len = op_size, .next_byte_read = next_byte_read };
         ssize_t read = Curl_bufq_pass(&q, bufq_writer_cb, &ctx, &err);
         if (read != -1) {
@@ -281,8 +281,8 @@ int fuzz_handle_bufq(FuzzedDataProvider *fuzz)
       }
 
       case OP_TYPE_SKIP: {
-        uint32_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
-        FV_PRINTF(verbose, "OP: skip, size %u\n", op_size);
+        size_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
+        FV_PRINTF(verbose, "OP: skip, size %zu\n", op_size);
         Curl_bufq_skip(&q, op_size);
         ssize_t old_buffer_bytes = buffer_bytes;
         buffer_bytes = old_buffer_bytes > op_size ? old_buffer_bytes - op_size : 0;
@@ -291,8 +291,8 @@ int fuzz_handle_bufq(FuzzedDataProvider *fuzz)
       }
 
       case OP_TYPE_WRITE: {
-        uint32_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
-        FV_PRINTF(verbose, "OP: write, size %u, begins with %x\n", op_size, next_byte_write);
+        size_t op_size = fuzz->ConsumeIntegralInRange(0, FUZZ_MAX_RW_SIZE);
+        FV_PRINTF(verbose, "OP: write, size %zu, begins with %x\n", op_size, next_byte_write);
         unsigned char *buf = compute_buffer(next_byte_write, template_buf);
         ssize_t written = Curl_bufq_write(&q, buf, op_size, &err);
         if (written != -1) {


### PR DESCRIPTION
These warnings and errors were observed on today's OSS-Fuzz build logs[1] and mostly concern the different type widths on i386.

[1]: https://oss-fuzz-build-logs.storage.googleapis.com/index.html#curl