### PR TITLE
Just use the bare versions in the versions file.

### DIFF
--- a/scripts/VERSIONS
+++ b/scripts/VERSIONS
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Handled by renovate.json
-OPENSSL_VERSION=openssl-3.2.0
+OPENSSL_VERSION=3.2.0
 
 # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
-NGHTTP2_VERSION=v1.58.0
+NGHTTP2_VERSION=1.58.0

--- a/scripts/download_nghttp2.sh
+++ b/scripts/download_nghttp2.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $SCRIPT_DIR/VERSIONS
 
 # Clone the repository to the specified directory.
-git clone --depth 1 --branch ${NGHTTP2_VERSION} https://github.com/nghttp2/nghttp2 $1
+git clone --depth 1 --branch v${NGHTTP2_VERSION} https://github.com/nghttp2/nghttp2 $1

--- a/scripts/download_openssl.sh
+++ b/scripts/download_openssl.sh
@@ -8,4 +8,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 source $SCRIPT_DIR/VERSIONS
 
 # Clone the repository to the specified directory.
-git clone --depth 1 --branch ${OPENSSL_VERSION} https://github.com/openssl/openssl $1
+git clone --depth 1 --branch openssl-${OPENSSL_VERSION} https://github.com/openssl/openssl $1


### PR DESCRIPTION
Renovate doesn't add prefixes to versions - so add them in the scripts instead