### PR TITLE
renovate: Fix openssl versioning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,7 +21,8 @@
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "openssl/openssl",
-      "versioningTemplate": "regex:^openssl-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^openssl-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "registryUrlTemplate": "https://github.com"
     }
   ],


### PR DESCRIPTION
Renovate isn't picking up openssl again. Fix it so it does.