### PR TITLE
Makefile: make sure libstandaloneengine gets built first

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -144,6 +144,8 @@ curl_fuzzer_bufq_SOURCES = fuzz_bufq.cc
 curl_fuzzer_bufq_CXXFLAGS = $(COMMON_FLAGS)
 curl_fuzzer_bufq_LDADD = $(COMMON_LDADD)
 
+all: $(FUZZLIBS) $(FUZZPROGS)
+
 # Create the seed corpora zip files.
 zip:
 	BUILD_ROOT=$(PWD) scripts/create_zip.sh


### PR DESCRIPTION
The build can easily break and require a manual 'make libstandaloneengine.a' without this precaution that makes sure the lib is built first.

Ref: #19