### PR TITLE
Add i386 test build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,15 @@ jobs:
           sudo apt-get install -y cmake clang
       - name: Compile deps target
         run: ./scripts/compile_target.sh deps
+
+  # Ensure that the repository can be built for i386
+  Testi386:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'curl'
+        dry-run: false
+        keep-unaffected-fuzz-targets: true
+        architecture: 'i386'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,12 @@ if(NOT (DEFINED ENV{SANITIZER} AND "$ENV{SANITIZER}" STREQUAL "memory"))
     set(OPENSSL_SRC_DIR ${CMAKE_BINARY_DIR}/openssl/src/openssl_external)
 
     # Architecture and sanitizer logic
-    set(OPENSSL_ARCH_PROG "")
+    set(OPENSSL_ARCH_TARGET "")
+    set(OPENSSL_ARCH_FLAG "")
     set(OPENSSL_EC_FLAG "enable-ec_nistp_64_gcc_128")
     if(DEFINED ENV{ARCHITECTURE} AND "$ENV{ARCHITECTURE}" STREQUAL "i386")
-        set(OPENSSL_ARCH_PROG "setarch i386")
+        set(OPENSSL_ARCH_TARGET "linux-generic32")
+        set(OPENSSL_ARCH_FLAG "386")
         set(OPENSSL_EC_FLAG "no-threads")
     endif()
 
@@ -70,14 +72,17 @@ if(NOT (DEFINED ENV{SANITIZER} AND "$ENV{SANITIZER}" STREQUAL "memory"))
 
     # Compose the config command
     set(OPENSSL_CONFIGURE_COMMAND
-        ${OPENSSL_ARCH_PROG} ./config
+        ./Configure
+        ${OPENSSL_ARCH_TARGET}
         --prefix=${OPENSSL_INSTALL_DIR}
         --libdir=lib
         --debug
         -DPEDANTIC
         -DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         no-shared
+        no-tests
         ${OPENSSL_ASM_FLAG}
+        ${OPENSSL_ARCH_FLAG}
         enable-tls1_3
         enable-rc5
         enable-md2

--- a/scripts/compile_target.sh
+++ b/scripts/compile_target.sh
@@ -46,6 +46,13 @@ echo "CFLAGS: ${CFLAGS:-undefined}"
 echo "CXXFLAGS: ${CXXFLAGS:-undefined}"
 echo "ARCHITECTURE: ${ARCHITECTURE:-undefined}"
 
+if [[ "${ARCHITECTURE:-}" == "i386" ]]
+then
+    CMAKE_VERBOSE_FLAG="-v"
+else
+    CMAKE_VERBOSE_FLAG=""
+fi
+
 export MAKEFLAGS+="-j$(nproc)"
 
 # Create a build directory for the dependencies.
@@ -55,5 +62,5 @@ mkdir -p ${BUILD_DIR}
 # Compile the dependencies.
 pushd ${BUILD_DIR}
 cmake ${CMAKE_GDB_FLAG} ..
-cmake --build . --target ${TARGET}
+cmake --build . --target ${TARGET} ${CMAKE_VERBOSE_FLAG}
 popd


### PR DESCRIPTION
In order to regressibly test the i386 build, add it as an architecture option.