### PR TITLE
ci: Add groff-base as a dependency to install

### DIFF
--- a/scripts/ossfuzzdeps.sh
+++ b/scripts/ossfuzzdeps.sh
@@ -31,4 +31,5 @@ $SUDO apt-get install -y make \
                    zlib1g-dev \
                    pkg-config \
                    wget \
-                   cmake
+                   cmake \
+                   groff-base


### PR DESCRIPTION
LDAP needs this installed, so we have a two step process whereby this needs to be in master before it gets picked up by CI. Slightly tedious but ok.