### PR TITLE
cmake: add mirror for the openldap tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,8 @@ endif()
 
 # Install OpenLDAP
 set(OPENLDAP_VERSION 2.6.10)
-set(OPENLDAP_URL https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${OPENLDAP_VERSION}.tgz)
+set(OPENLDAP_URL https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${OPENLDAP_VERSION}.tgz
+                 https://mirror.koddos.net/OpenLDAP/openldap-release/openldap-${OPENLDAP_VERSION}.tgz)
 set(OPENLDAP_INSTALL_DIR ${CMAKE_BINARY_DIR}/openldap-install)
 set(OPENLDAP_STATIC_LIB_LDAP ${OPENLDAP_INSTALL_DIR}/lib/libldap.a)
 set(OPENLDAP_STATIC_LIB_LBER ${OPENLDAP_INSTALL_DIR}/lib/liblber.a)


### PR DESCRIPTION
Ref: https://www.openldap.org/software/download/

Note: new releases may not be available on the mirrors.

```
CMake Error at openldap_external-stamp/download-openldap_external.cmake:163 (message):
  Each download failed!

    error: downloading 'https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-2.6.10.tgz' failed
          status_code: 28
          status_string: "Timeout was reached"
          log:
          --- LOG BEGIN ---
          timeout on name lookup is not supported
```
Ref: https://github.com/curl/curl/actions/runs/17893469923/job/50876989019?pr=18660#step:4:1523