### PR TITLE
ci: cache builds to improve speed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,26 @@ jobs:
   BuildFuzzers:
     name: 'Build fuzzers'
     runs-on: ubuntu-latest
+    env:
+      # Must match the path ossfuzz.sh writes to when CIFUZZ=True.
+      CACHE_PATH: .ossfuzz-build-cache-address-x86_64
     steps:
+      # Check out curl-fuzzer on the runner so the cache key can hash the
+      # build-definition files. CIFuzz still uses its own clone baked into the
+      # gcr.io/oss-fuzz/curl image, so this checkout does not affect the build.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Restore build cache
+        id: build-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ env.CACHE_PATH }}
+          key: ossfuzz-build-v1-${{ runner.os }}-address-x86_64-${{ hashFiles('CMakeLists.txt', 'scripts/compile_target.sh', 'scripts/ossfuzzdeps.sh', 'ossfuzz.sh') }}
+          restore-keys: |
+            ossfuzz-build-v1-${{ runner.os }}-address-x86_64-
+
       # Use the CIFuzz job to test the repository.
       - name: Build Fuzzers
         uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master  # zizmor: ignore[unpinned-uses]
@@ -51,6 +70,13 @@ jobs:
           oss-fuzz-project-name: 'curl'
           dry-run: false
           keep-unaffected-fuzz-targets: true
+
+      - name: Save build cache
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ env.CACHE_PATH }}
+          key: ossfuzz-build-v1-${{ runner.os }}-address-x86_64-${{ hashFiles('CMakeLists.txt', 'scripts/compile_target.sh', 'scripts/ossfuzzdeps.sh', 'ossfuzz.sh') }}
 
       # Archive the fuzzer output (which maintains permissions)
       - name: Create fuzz tar

--- a/ossfuzz.sh
+++ b/ossfuzz.sh
@@ -35,6 +35,26 @@ echo "FUZZ_TARGETS: $FUZZ_TARGETS"
 # Set the CURL_SOURCE_DIR for the build.
 export CURL_SOURCE_DIR=/src/curl
 
+# Under CIFuzz the build runs in an ephemeral container, but $GITHUB_WORKSPACE
+# is bind-mounted into the container path-for-path and $OUT lives directly
+# beneath it. Redirect the CMake build tree into that mount so it survives
+# container teardown and GitHub Actions can cache it between runs.
+if [[ "${CIFUZZ:-}" == "True" && -n "${OUT:-}" ]]; then
+  CACHE_ROOT=$(dirname "${OUT}")/.ossfuzz-build-cache-${SANITIZER:-address}-${ARCHITECTURE:-x86_64}
+  export BUILD_DIR=${CACHE_ROOT}/build
+  mkdir -p "${BUILD_DIR}"
+  echo "CIFuzz detected: redirecting BUILD_DIR to ${BUILD_DIR}"
+
+  # Curl is cloned fresh (--depth 1) on every container start, but its CMake
+  # ExternalProject stamp would skip rebuilding if we kept it. Drop the stamps
+  # and the built library so curl (and the fuzzer binaries that link it) get
+  # rebuilt against the current tip. Mirrors the REPLAY_ENABLED handling in
+  # oss-fuzz/projects/curl/build.sh.
+  rm -f "${BUILD_DIR}/curl-install/lib/libcurl.a"
+  rm -f "${BUILD_DIR}"/curl_external-prefix/src/curl_external-stamp/curl_external-{configure,build,install,done}
+fi
+BUILD_DIR=${BUILD_DIR:-${BUILD_ROOT}/build}
+
 # Compile the fuzzers.
 "${SCRIPTDIR}"/compile_target.sh fuzz
 
@@ -44,7 +64,7 @@ scripts/create_zip.sh
 # Copy the fuzzers over.
 for TARGET in $FUZZ_TARGETS
 do
-  cp -v build/"${TARGET}" "${TARGET}_seed_corpus.zip" "$OUT"/
+  cp -v "${BUILD_DIR}/${TARGET}" "${TARGET}_seed_corpus.zip" "$OUT"/
 done
 
 # Copy dictionary and options file to $OUT.

--- a/scripts/compile_target.sh
+++ b/scripts/compile_target.sh
@@ -58,16 +58,19 @@ fi
 export MAKEFLAGS; MAKEFLAGS+=" -s -j$(($(nproc) + 0))"
 echo "MAKEFLAGS: ${MAKEFLAGS}"
 
-# Create a build directory for the dependencies.
-BUILD_DIR=${BUILD_ROOT}/build
+# Create a build directory for the dependencies. Honour BUILD_DIR if caller set
+# it (e.g. to redirect into a cache mount under CIFuzz); default to the
+# in-tree build/.
+BUILD_DIR=${BUILD_DIR:-${BUILD_ROOT}/build}
 mkdir -p "${BUILD_DIR}"
 
 options=''
 command -v ninja >/dev/null 2>&1 && options+=' -G Ninja'
 
-# Compile the dependencies.
+# Compile the dependencies. Point cmake at BUILD_ROOT explicitly rather than
+# relying on "..", so BUILD_DIR can live outside the source tree (cache mount).
 pushd "${BUILD_DIR}"
 # shellcheck disable=SC2086
-cmake "${CMAKE_GDB_FLAG}" .. ${options}
+cmake "${CMAKE_GDB_FLAG}" "${BUILD_ROOT}" ${options}
 cmake --build . --target "${TARGET}" ${CMAKE_VERBOSE_FLAG}
 popd


### PR DESCRIPTION
This pull request introduces a build cache for the fuzzers in CI to speed up repeated runs, especially under CIFuzz, and ensures that build artifacts are properly reused and rebuilt as needed. The main changes involve redirecting the build output to a cacheable directory, updating scripts to respect this directory, and integrating cache restore/save steps into the GitHub Actions workflow.

**CI workflow and build caching:**

* Added steps to restore and save the fuzzer build cache in the `BuildFuzzers` job of `.github/workflows/ci.yml`, using `actions/cache` to persist the build output between runs. The cache key is based on build definition files to ensure cache validity. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR46-R65) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR74-R80)
* Checked out the repository in the workflow to enable cache key generation based on the current source.

**Build directory handling and script updates:**

* Modified `ossfuzz.sh` to detect CIFuzz runs and redirect the CMake build tree into a cacheable directory beneath the workspace, ensuring build artifacts survive container teardown and are cacheable. Also, forcibly rebuilds curl and fuzzers to avoid stale binaries.
* Updated `scripts/compile_target.sh` to honor a pre-set `BUILD_DIR` (for caching), defaulting to the in-tree build directory if not set, and to explicitly point CMake at the source root so the build directory can be outside the source tree.
* Changed the fuzzer artifact copy step in `ossfuzz.sh` to use `${BUILD_DIR}` instead of a hardcoded build path, ensuring correct artifact locations when caching is enabled.