### PR TITLE
GHA/ci: set time limits for steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,12 @@ jobs:
     name: 'Run fuzzers'
     needs: [BuildFuzzers, DetermineMatrix]
     runs-on: ubuntu-latest
+    timeout-minutes: 8
     strategy:
       matrix: ${{ fromJSON(needs.DetermineMatrix.outputs.matrix) }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        timeout-minutes: 1
         with:
           name: fuzz_tar
       - name: Unpack fuzzer ${{ matrix.fuzzer }}
@@ -110,6 +112,7 @@ jobs:
         run: ls -laR build-out/
       - name: Run Fuzzer ${{ matrix.fuzzer }}
         uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master  # zizmor: ignore[unpinned-uses]
+        timeout-minutes: 6
         with:
           oss-fuzz-project-name: 'curl'
           fuzz-seconds: 120

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       matrix: ${{ fromJSON(needs.DetermineMatrix.outputs.matrix) }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        timeout-minutes: 1
+        timeout-minutes: 2
         with:
           name: fuzz_tar
       - name: Unpack fuzzer ${{ matrix.fuzzer }}


### PR DESCRIPTION
- download artifacts normally takes 8-16 seconds. Limit: 2 minutes
  Artifact size is ~300 MB.
- run fuzzer normally takes 2.5-3.5 minutes. Limit: 6 minutes
- all steps normally finish in 3.5-4.5 minutes. Limit: 8 minutes

To avoid steps hanging without limit due to broken or very slow servers:
```
Preparing to download the following artifacts:
- fuzz_tar (ID: 6943363525, Size: 297646278, Expected Digest: sha256:32d1c580cd00a8a34613a2790597ca1fb903a961b4f98a1b758831a503bd6925)
Redirecting to blob download url: https://productionresultssa14.blob.core.windows.net/actions-results/27b8db0e-3c82-438b-b07c-4453c7fb1ec9/workflow-job-run-fa5e0451-34c9-57b4-9042-c37682bd0829/artifacts/aad183c713929ed3b31f33b3a08ec67cf5ff8ef9d858d2f04600381efec46c6e.zip
Starting download of artifact to: /home/runner/work/curl/curl
(node:2488) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```
Ref: https://github.com/curl/curl/actions/runs/25732379940/job/75561660727?pr=21566

Bug: https://github.com/curl/curl/issues/21556#issuecomment-4430355713