### PR TITLE
bufq: reduce fuzz_bufq operation size limits to avoid timeouts

### DIFF
--- a/fuzz_bufq.h
+++ b/fuzz_bufq.h
@@ -24,8 +24,8 @@
  * Limits for fields
  */
 #define FUZZ_MAX_CHUNK_SIZE      (16 * 1024)
-#define FUZZ_MAX_CHUNKS_QTY      (1 * 1024)
-#define FUZZ_MAX_MAX_SPARE       (1 * 1024)
+#define FUZZ_MAX_CHUNKS_QTY      16
+#define FUZZ_MAX_MAX_SPARE       16
 #define FUZZ_MAX_RW_SIZE         (FUZZ_MAX_CHUNKS_QTY * FUZZ_MAX_CHUNK_SIZE)
 
 /**


### PR DESCRIPTION
FUZZ_MAX_CHUNKS_QTY and FUZZ_MAX_MAX_SPARE were set to 1024, making FUZZ_MAX_RW_SIZE 16MB. With a large input driving ~100k iterations, each read or write operation could allocate and process up to 16MB, causing ClusterFuzz to report a timeout.

Reduce both limits to 16, capping FUZZ_MAX_RW_SIZE at 256KB. This is still large enough to exercise all meaningful bufq behaviour while keeping individual testcase execution well under a second.