### PR TITLE
openssl: Drop enable-ssl3/enable-ssl3-method Configure flags for OpenSSL 4.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,3 +137,21 @@ jobs:
         with:
           name: artifacts
           path: ./out/artifacts
+
+  Success:
+    name: 'Success'
+    # Single required status check: green only when every RunFuzzers matrix
+    # leg succeeded.
+    needs: [RunFuzzers]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check RunFuzzers result
+        env:
+          RESULT: ${{ needs.RunFuzzers.result }}
+        run: |
+          if [ "${RESULT}" != "success" ]; then
+            echo "RunFuzzers did not succeed: ${RESULT}"
+            exit 1
+          fi
+          echo "All fuzzers ran successfully."

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,9 +121,7 @@ if(NOT "$ENV{SANITIZER}" STREQUAL "memory")
         enable-tls1_3
         enable-rc5
         enable-md2
-        enable-ssl3
         ${OPENSSL_EC_FLAG}
-        enable-ssl3-method
         enable-nextprotoneg
         enable-weak-ssl-ciphers
         --with-zlib-include=${ZLIB_INSTALL_DIR}/include


### PR DESCRIPTION
OpenSSL 4.0 removed SSLv3 entirely, so ./Configure hard-errors on the enable-ssl3 and enable-ssl3-method options ("Unsupported options"). This broke the OpenSSL v4 renovate update  at the configure step in every job that builds OpenSSL from source.

Removing these flags is backwards-compatible with the current 3.6.x pin (curl is simply no longer built with SSLv3 support), and unblocks the move to 4.x where the SSLv3 code no longer exists to fuzz.