### PR TITLE
tidy-up: minor nits

### DIFF
--- a/curl_fuzzer.cc
+++ b/curl_fuzzer.cc
@@ -169,7 +169,6 @@ EXIT_LABEL:
 int fuzz_set_easy_options(FUZZ_DATA *fuzz)
 {
   int rc = 0;
-  unsigned long allowed_protocols;
 
   /* Set some standard options on the CURL easy handle. We need to override the
      socket function so that we create our own sockets to present to CURL. */

--- a/curl_fuzzer.cc
+++ b/curl_fuzzer.cc
@@ -423,7 +423,7 @@ int fuzz_handle_transfer(FUZZ_DATA *fuzz)
      handle. */
   curl_multi_cleanup(multi_handle);
 
-  return(rc);
+  return rc;
 }
 
 /**
@@ -480,7 +480,7 @@ int fuzz_send_next_response(FUZZ_DATA *fuzz, FUZZ_SOCKET_MANAGER *sman)
     sman->fd_state = FUZZ_SOCK_SHUTDOWN;
   }
 
-  return(rc);
+  return rc;
 }
 
 /**

--- a/curl_fuzzer.cc
+++ b/curl_fuzzer.cc
@@ -496,7 +496,7 @@ int fuzz_select(int nfds,
 /**
  * Set allowed protocols based on the compile options.
  *
- * Note that it can only use ONE of the FUZZ_PROTOCOLS_* defines.a
+ * Note that it can only use ONE of the FUZZ_PROTOCOLS_* defines.
  */
 int fuzz_set_allowed_protocols(FUZZ_DATA *fuzz)
 {

--- a/curl_fuzzer_callback.cc
+++ b/curl_fuzzer_callback.cc
@@ -206,7 +206,7 @@ size_t fuzz_read_callback(char *buffer,
     fuzz->upload1_data_written += remaining_data;
   }
 
-  return(remaining_data);
+  return remaining_data;
 }
 
 /**

--- a/curl_fuzzer_tlv.cc
+++ b/curl_fuzzer_tlv.cc
@@ -515,7 +515,7 @@ int fuzz_add_mime_part(TLV *src_tlv, curl_mimepart *part)
 
 EXIT_LABEL:
 
-  return(rc);
+  return rc;
 }
 
 /**


### PR DESCRIPTION
- drop redundant parentheses.
- drop unused variable.
- fix comment typo.

Reported by GitHub Code Quality
