### PR TITLE
CI fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,7 @@ if(BUILD_GDB)
     # clean flags so sanitizer/fuzzer flags don't break its build.
     ExternalProject_Add(gdb_external
         URL ${GDB_URL}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
         PREFIX ${CMAKE_BINARY_DIR}/${GDB_BUILD_NAME}
         CONFIGURE_COMMAND ${CMAKE_COMMAND} -E env
             "CC=gcc" "CXX=g++"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,8 +633,23 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     set(LPM_PB_INCLUDE ${LPM_PB_DIR}/include)
     set(LPM_PB_LIBDIR ${LPM_PB_DIR}/lib)
     set(LPM_PROTOC ${LPM_PB_DIR}/bin/protoc)
+    set(LPM_PB_SOURCE_DIR ${LPM_PB_DIR}/src/external.protobuf)
+    set(HOST_PROTOC_BUILD_DIR
+        ${CMAKE_BINARY_DIR}/${LPM_BUILD_NAME}-host-protoc-build)
+    set(HOST_PROTOC_INSTALL_DIR
+        ${CMAKE_BINARY_DIR}/${LPM_BUILD_NAME}-host-protoc-install)
+    set(HOST_PROTOC ${HOST_PROTOC_INSTALL_DIR}/bin/protoc)
 
-    if(NOT EXISTS ${LPM_STATIC_LIB} OR NOT EXISTS ${LPM_PROTOC})
+    # A cache created before the clean host tool existed contains LPM's install
+    # outputs but not its protobuf source. Rebuild LPM once in that case so the
+    # MSan-only host build below has the exact matching source available.
+    set(HOST_PROTOC_NEEDS_SOURCE FALSE)
+    if("$ENV{SANITIZER}" STREQUAL "memory" AND NOT EXISTS ${HOST_PROTOC})
+        set(HOST_PROTOC_NEEDS_SOURCE TRUE)
+    endif()
+    if(NOT EXISTS ${LPM_STATIC_LIB} OR NOT EXISTS ${LPM_PROTOC} OR
+       (HOST_PROTOC_NEEDS_SOURCE AND
+        NOT EXISTS ${LPM_PB_SOURCE_DIR}/CMakeLists.txt))
         ExternalProject_Add(libprotobuf_mutator_external
             GIT_REPOSITORY https://github.com/google/libprotobuf-mutator.git
             GIT_TAG ${LPM_VERSION}
@@ -653,6 +668,56 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     else()
         message(STATUS "LPM already installed at ${LPM_INSTALL_DIR}, skipping build")
         add_custom_target(libprotobuf_mutator_external)
+    endif()
+
+    set(GENERATOR_PROTOC ${LPM_PROTOC})
+    set(GENERATOR_PROTOC_DEP libprotobuf_mutator_external)
+    if("$ENV{SANITIZER}" STREQUAL "memory")
+        # LPM correctly instruments its bundled protobuf libraries, but that
+        # also instruments protoc. A host tool linked to the runner's ordinary
+        # libstdc++ produces false MSan reports before it can generate inputs.
+        # Build protoc again from the same source with clean flags, while
+        # retaining the instrumented libraries linked into the fuzz targets.
+        if(NOT EXISTS ${HOST_PROTOC})
+            add_custom_command(
+                OUTPUT ${HOST_PROTOC}
+                COMMAND ${CMAKE_COMMAND} -E env
+                        --unset=CFLAGS --unset=CXXFLAGS
+                        --unset=CPPFLAGS --unset=LDFLAGS
+                        ${CMAKE_COMMAND}
+                        -S ${LPM_PB_SOURCE_DIR}
+                        -B ${HOST_PROTOC_BUILD_DIR}
+                        -G "${CMAKE_GENERATOR}"
+                        -DCMAKE_INSTALL_PREFIX=${HOST_PROTOC_INSTALL_DIR}
+                        -DCMAKE_BUILD_TYPE=Release
+                        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                        -DCMAKE_C_FLAGS=
+                        -DCMAKE_CXX_FLAGS=
+                        -DCMAKE_EXE_LINKER_FLAGS=
+                        -DCMAKE_CXX_STANDARD=14
+                        -Dprotobuf_INSTALL=ON
+                        -Dprotobuf_BUILD_TESTS=OFF
+                        -Dprotobuf_BUILD_CONFORMANCE=OFF
+                        -Dprotobuf_BUILD_EXAMPLES=OFF
+                        -Dprotobuf_BUILD_LIBUPB=OFF
+                        -Dprotobuf_BUILD_SHARED_LIBS=OFF
+                        -Dprotobuf_WITH_ZLIB=OFF
+                COMMAND ${CMAKE_COMMAND} --build ${HOST_PROTOC_BUILD_DIR}
+                        --config Release --target protoc --parallel
+                COMMAND ${CMAKE_COMMAND} --install ${HOST_PROTOC_BUILD_DIR}
+                        --config Release --component protoc
+                DEPENDS libprotobuf_mutator_external
+                COMMENT "Building uninstrumented host protoc"
+                VERBATIM
+            )
+            add_custom_target(host_protoc DEPENDS ${HOST_PROTOC})
+        else()
+            add_custom_target(host_protoc)
+            add_dependencies(host_protoc libprotobuf_mutator_external)
+        endif()
+        set(GENERATOR_PROTOC ${HOST_PROTOC})
+        set(GENERATOR_PROTOC_DEP host_protoc)
     endif()
 
     # Generate the expanded .proto and the C++ option manifest from curl.h.
@@ -683,11 +748,11 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
 
     add_custom_command(
         OUTPUT ${GEN_PB_CC} ${GEN_PB_H}
-        COMMAND ${LPM_PROTOC}
+        COMMAND ${GENERATOR_PROTOC}
                 --cpp_out=${CMAKE_BINARY_DIR}
                 --proto_path=${PROTO_FUZZER_SCHEMA_DIR}
                 ${GEN_PROTO}
-        DEPENDS ${GEN_PROTO} libprotobuf_mutator_external
+        DEPENDS ${GEN_PROTO} ${GENERATOR_PROTOC} ${GENERATOR_PROTOC_DEP}
         COMMENT "protoc curl_fuzzer.proto"
         VERBATIM
     )
@@ -907,12 +972,13 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
                 OUTPUT ${out}
                 COMMAND ${CMAKE_COMMAND} -E make_directory ${scenario_out_dir}
                 COMMAND ${CMAKE_SOURCE_DIR}/scripts/encode_scenario.sh
-                        ${LPM_PROTOC}
+                        ${GENERATOR_PROTOC}
                         ${PROTO_FUZZER_SCHEMA_DIR}
                         ${GEN_PROTO}
                         ${textproto}
                         ${out}
-                DEPENDS ${textproto} ${GEN_PROTO} libprotobuf_mutator_external
+                DEPENDS ${textproto} ${GEN_PROTO} ${GENERATOR_PROTOC}
+                        ${GENERATOR_PROTOC_DEP}
                         ${CMAKE_SOURCE_DIR}/scripts/encode_scenario.sh
                 COMMENT "Encoding ${name}.textproto for ${_output_name}"
                 VERBATIM

--- a/mainline.sh
+++ b/mainline.sh
@@ -25,17 +25,29 @@ shift $((OPTIND-1))
 export CC=clang
 export CXX=clang++
 FUZZ_FLAG="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION"
-export CFLAGS="-fsanitize=address,fuzzer-no-link"
-export CXXFLAGS="-fsanitize=address,fuzzer-no-link -stdlib=libstdc++ $FUZZ_FLAG"
+export SANITIZER="${SANITIZER:-address}"
+SANITIZER_FLAGS="-fsanitize=${SANITIZER},fuzzer-no-link"
+export CFLAGS="$SANITIZER_FLAGS"
+export CXXFLAGS="$SANITIZER_FLAGS -stdlib=libstdc++ $FUZZ_FLAG"
 export CPPFLAGS="$FUZZ_FLAG"
 export OPENSSLFLAGS="-fno-sanitize=alignment -lstdc++"
 
+# CMake and the external dependencies cache their initial compiler flags.
+# Keep local MSan artefacts away from the historical ASan build directory so
+# switching sanitizers cannot silently produce a mixed-instrumentation binary.
+if [[ -z "${BUILD_DIR:-}" && "${SANITIZER}" == "memory" ]]; then
+  export BUILD_DIR="${BUILD_ROOT}/build-memory"
+fi
+
 "${SCRIPTDIR}"/compile_target.sh "${TARGET}"
 
-# Building fuzzers alone only checks that the regression tests compile. Run
-# the allocation-free TLV mutator and proto policy tests on every normal
-# mainline build so mutation invariants cannot regress behind a green CI job.
-if [[ "${TARGET}" == "fuzz" ]]; then
+# The fuzz target does not execute regression tests. Run the allocation-free
+# TLV mutator and proto policy tests on AddressSanitizer builds so mutation
+# invariants cannot regress behind a green CI job. The
+# runner's distro libstdc++ is not MSan-instrumented, so executing these tests
+# in the memory lane would turn library-boundary false positives into failures;
+# that lane remains a genuine instrumented compile/link check.
+if [[ "${TARGET}" == "fuzz" && "${SANITIZER}" != "memory" ]]; then
   TEST_BUILD_DIR="${BUILD_DIR:-${BUILD_ROOT}/build}"
   cmake --build "${TEST_BUILD_DIR}" --target fuzzer_unit_tests
   ctest --test-dir "${TEST_BUILD_DIR}" --output-on-failure


### PR DESCRIPTION
This pull request introduces significant improvements to the build system, particularly around sanitizer support and the handling of protobuf toolchains for fuzzing. The changes ensure clean separation of build artifacts for different sanitizers, robust handling of the `protoc` binary when using MemorySanitizer (MSan), and more flexible configuration of sanitizer options. Additionally, the build scripts have been updated to prevent false positives and ensure correct test execution under various sanitizer configurations.

Key improvements include:

**Sanitizer and Build Directory Handling:**

* The build scripts (`mainline.sh`) now set the sanitizer type dynamically via the `SANITIZER` environment variable, with improved flag management for both C and C++ builds. When using MemorySanitizer, build artifacts are isolated in a dedicated directory to prevent cross-contamination with other sanitizer builds.

**Protobuf/Protoc Toolchain for Fuzzing:**

* The CMake configuration (`CMakeLists.txt`) introduces logic to build an uninstrumented host `protoc` binary when using MemorySanitizer. This avoids false positives that can occur if an instrumented `protoc` is used with a non-instrumented standard library, ensuring correct input generation for fuzz targets. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL635-R652) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR673-R722)
* All custom commands that require `protoc` now depend on the correct (possibly uninstrumented) binary, and their dependencies are updated accordingly to ensure proper build order and correctness. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL685-R755) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL909-R981)

**Testing Logic Improvements:**

* The regression tests for fuzzers are now only executed on AddressSanitizer builds, not on MemorySanitizer builds, to avoid false positives due to non-instrumented system libraries. This ensures that mutation invariants remain tested without introducing spurious failures in MSan builds.

**Other Build Improvements:**

* The GDB external project now uses `DOWNLOAD_EXTRACT_TIMESTAMP TRUE` to ensure reproducible builds.

These changes collectively improve the reliability and correctness of fuzzing builds and their associated tests across different sanitizer configurations.

**References:**
- [mainline.shL28-R50](diffhunk://#diff-f4cf18174aecf3c84ac7f09b2e714508844a2508027235334c9ef2cf74e736d2L28-R50)
- [CMakeLists.txtR259](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR259)
- [CMakeLists.txtL635-R652](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL635-R652)
- [CMakeLists.txtR673-R722](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR673-R722)
- [CMakeLists.txtL685-R755](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL685-R755)
- [CMakeLists.txtL909-R981](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL909-R981)