### PR TITLE
proto: add dedicated FTP and TFTP fuzzers

### DIFF
--- a/BENCHMARKING.md
+++ b/BENCHMARKING.md
@@ -20,8 +20,9 @@ scripts/compare_fuzzers.py \
   --output build/measurements/comparison.json
 ```
 
-The defaults cover the legacy HTTP/HTTPS/WS targets and the fixed structured
-fast HTTP, deep HTTP, HTTPS, WS, WSS, and timing lanes. The deep HTTP target
+The defaults cover the legacy FTP/HTTP/HTTPS/TFTP/WS targets and the fixed
+structured fast HTTP, deep HTTP, HTTPS, WS, WSS, TELNET, FTP, TFTP, API, and
+timing lanes. The deep HTTP target
 retains stateful authentication, redirect, upload, MIME, and result-probe
 work so the ordinary HTTP lane can concentrate its CPU budget on single-request
 URL and response parsing. The original mixed-semantics
@@ -49,6 +50,8 @@ scripts/compare_fuzzers.py \
   --candidate-dir /path/to/proto/out/curl \
   --target-pair curl_fuzzer_http=curl_fuzzer_proto_http \
   --target-pair curl_fuzzer_https=curl_fuzzer_proto_https \
+  --target-pair curl_fuzzer_ftp=curl_fuzzer_proto_ftp \
+  --target-pair curl_fuzzer_tftp=curl_fuzzer_proto_tftp \
   --target-pair curl_fuzzer_ws=curl_fuzzer_proto_ws
 ```
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,9 +335,13 @@ set(CURL_CMAKE_ARGS
     -DCURL_HIDDEN_SYMBOLS=OFF
     -DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
     -DCURL_USE_LIBPSL=OFF
-    # TELNET has no feature bit, so make the coverage dependency explicit and
-    # verify the advertised protocol list in curl_features_test as well.
+    # These protocol parsers have no feature bits. Make their coverage
+    # dependencies explicit and verify curl's advertised protocol list too,
+    # so a default change cannot silently turn a dedicated target into a URL
+    # rejection benchmark.
     -DCURL_DISABLE_TELNET=OFF
+    -DCURL_DISABLE_FTP=OFF
+    -DCURL_DISABLE_TFTP=OFF
     ${CURL_SSL_OPTION}
     -DZLIB_INCLUDE_DIR=${ZLIB_INSTALL_DIR}/include
     -DZLIB_LIBRARY=${ZLIB_STATIC_LIB}
@@ -805,16 +809,19 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     )
     add_custom_target(lpm_link_rsp DEPENDS ${LPM_LINK_RSP})
 
-    # The protocol runners and generated message are identical for every
-    # structured target. Compile them once; fuzzer_main.cc carries the
-    # per-binary profile while a same-named thin entrypoint gives Introspector
-    # an unambiguous static-profile-to-coverage mapping.
+    # The protocol runners, LPM adapter, and generated message are identical
+    # for every structured target. Compile them once; each same-named thin
+    # entrypoint passes its profile explicitly, giving Introspector an
+    # unambiguous static-profile-to-coverage mapping without target-specific
+    # compiler definitions.
     set(PROTO_FUZZER_TLS_SOURCES)
     if(TARGET openssl_external)
         list(APPEND PROTO_FUZZER_TLS_SOURCES proto_fuzzer/tls_mock_server.cc)
     endif()
     add_library(curl_fuzzer_proto_runtime OBJECT
         proto_fuzzer/api_lifecycle.cc
+        proto_fuzzer/fuzzer_main.cc
+        proto_fuzzer/ftp_mock_server.cc
         proto_fuzzer/scenario_runner.cc
         proto_fuzzer/option_apply.cc
         proto_fuzzer/request_data.cc
@@ -824,6 +831,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         proto_fuzzer/target_policy.cc
         proto_fuzzer/telnet_mock_server.cc
         proto_fuzzer/telnet_scenario.cc
+        proto_fuzzer/tftp_mock_server.cc
         ${PROTO_FUZZER_TLS_SOURCES}
         proto_fuzzer/websocket_mock_server.cc
         proto_fuzzer/ws_frame.cc
@@ -855,20 +863,17 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         lpm_link_rsp
     )
 
-    # Build one compatibility binary plus fixed protocol/cost lanes. The
-    # compile definition is consumed only by fuzzer_main.cc. Fixed lanes
-    # register the matching LPM postprocessor before the first corpus input is
-    # decoded; the compatibility lane intentionally registers none.
-    function(curl_add_proto_fuzzer _name _profile_definition)
+    # Build one compatibility binary plus fixed protocol/cost lanes. Each
+    # entrypoint binds its TargetProfile in ordinary C++, keeping build-system
+    # wiring independent of mutation and execution behaviour.
+    function(curl_add_proto_fuzzer _name)
         add_executable(${_name}
             fuzzer_entrypoints/${_name}.cc
-            proto_fuzzer/fuzzer_main.cc
             $<TARGET_OBJECTS:curl_fuzzer_proto_runtime>
         )
         target_compile_features(${_name} PRIVATE cxx_std_17)
         target_compile_options(${_name} PRIVATE
             ${COMMON_FLAGS} -DFUZZ_PROTOCOLS_HTTP)
-        target_compile_definitions(${_name} PRIVATE ${_profile_definition})
         target_include_directories(${_name} PRIVATE
             ${CURL_INCLUDE_DIRS}
             ${CMAKE_BINARY_DIR}
@@ -908,15 +913,17 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     # Preserve the original mixed target's behavior under its original name:
     # OSS-Fuzz keys accumulated corpora and regression testcases by target
     # basename, so changing its profile would silently change their semantics.
-    curl_add_proto_fuzzer(curl_fuzzer_proto PROTO_FUZZER_TARGET_COMPATIBILITY)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_http PROTO_FUZZER_TARGET_FAST_HTTP)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_http_deep PROTO_FUZZER_TARGET_DEEP_HTTP)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_https PROTO_FUZZER_TARGET_FAST_HTTPS)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_ws PROTO_FUZZER_TARGET_FAST_WEBSOCKET)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_wss PROTO_FUZZER_TARGET_FAST_SECURE_WEBSOCKET)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_telnet PROTO_FUZZER_TARGET_FAST_TELNET)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_api PROTO_FUZZER_TARGET_API)
-    curl_add_proto_fuzzer(curl_fuzzer_proto_timing PROTO_FUZZER_TARGET_TIMING)
+    curl_add_proto_fuzzer(curl_fuzzer_proto)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_http)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_http_deep)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_https)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_ws)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_wss)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_telnet)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_ftp)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_tftp)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_api)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_timing)
 
     # Compile textproto seed scenarios into binary corpus entries. These are
     # derived artefacts — the textprotos in scenarios/ are the source of truth,
@@ -932,6 +939,10 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
          ${SCENARIO_SRC_DIR}/wss/*.textproto)
     file(GLOB TELNET_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
          ${SCENARIO_SRC_DIR}/telnet/*.textproto)
+    file(GLOB FTP_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
+         ${SCENARIO_SRC_DIR}/ftp/*.textproto)
+    file(GLOB TFTP_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
+         ${SCENARIO_SRC_DIR}/tftp/*.textproto)
     file(GLOB API_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
          ${SCENARIO_SRC_DIR}/api/*.textproto)
     file(GLOB_RECURSE TIMING_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
@@ -1074,6 +1085,10 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         ${FAST_WS_SCENARIO_TEXTPROTOS} ${WSS_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_telnet_corpus
         curl_fuzzer_proto_telnet ${TELNET_SCENARIO_TEXTPROTOS})
+    add_proto_fuzzer_corpus(curl_fuzzer_proto_ftp_corpus
+        curl_fuzzer_proto_ftp ${FTP_SCENARIO_TEXTPROTOS})
+    add_proto_fuzzer_corpus(curl_fuzzer_proto_tftp_corpus
+        curl_fuzzer_proto_tftp ${TFTP_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_api_corpus
         curl_fuzzer_proto_api ${API_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_timing_corpus
@@ -1087,6 +1102,8 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     add_dependencies(curl_fuzzer_proto_wss curl_fuzzer_proto_wss_corpus)
     add_dependencies(curl_fuzzer_proto_telnet
         curl_fuzzer_proto_telnet_corpus)
+    add_dependencies(curl_fuzzer_proto_ftp curl_fuzzer_proto_ftp_corpus)
+    add_dependencies(curl_fuzzer_proto_tftp curl_fuzzer_proto_tftp_corpus)
     add_dependencies(curl_fuzzer_proto_api curl_fuzzer_proto_api_corpus)
     add_dependencies(curl_fuzzer_proto_timing curl_fuzzer_proto_timing_corpus)
 
@@ -1204,6 +1221,55 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         add_test(NAME mock_server_test COMMAND mock_server_test)
         set_tests_properties(mock_server_test PROPERTIES TIMEOUT 5)
         add_dependencies(fuzzer_unit_tests mock_server_test)
+
+        # Protocol peers that need multi-socket coordination have focused
+        # executable tests. Keeping them outside mock_server_test makes their
+        # real FTP/TFTP transfers independently attributable and keeps the
+        # generic stream-mock test from becoming a protocol integration suite.
+        function(curl_add_proto_peer_test _name _test_source _peer_source)
+            add_executable(${_name}
+                ${_test_source}
+                ${_peer_source}
+                proto_fuzzer/mock_server.cc
+                proto_fuzzer/mock_server_base.cc
+                proto_fuzzer/multi_socket_driver.cc
+                proto_fuzzer/option_apply.cc
+                proto_fuzzer/request_data.cc
+                proto_fuzzer/ws_frame.cc
+                ${GEN_PB_CC}
+            )
+            target_compile_features(${_name} PRIVATE cxx_std_17)
+            target_compile_options(${_name} PRIVATE ${COMMON_FLAGS})
+            target_include_directories(${_name} PRIVATE
+                ${CURL_INCLUDE_DIRS}
+                ${CMAKE_BINARY_DIR}
+                ${CMAKE_SOURCE_DIR}
+                ${LPM_PB_INCLUDE}
+            )
+            target_link_libraries(${_name} PRIVATE
+                ${CURL_LIB_DIR}/libcurl.a
+                ${CURL_STATIC_DEPENDENCY_LIBS}
+                "-Wl,@${LPM_LINK_RSP}"
+                pthread
+                m
+            )
+            target_link_options(${_name} PRIVATE ${COVERAGE_LINK_FLAGS})
+            add_dependencies(${_name}
+                ${FUZZ_DEPS}
+                libprotobuf_mutator_external
+                lpm_link_rsp
+            )
+            add_test(NAME ${_name} COMMAND ${_name})
+            set_tests_properties(${_name} PROPERTIES TIMEOUT 5)
+            add_dependencies(fuzzer_unit_tests ${_name})
+        endfunction()
+
+        curl_add_proto_peer_test(tftp_mock_server_test
+            tests/tftp_mock_server_test.cc
+            proto_fuzzer/tftp_mock_server.cc)
+        curl_add_proto_peer_test(ftp_mock_server_test
+            tests/ftp_mock_server_test.cc
+            proto_fuzzer/ftp_mock_server.cc)
     endif()
 
     # Documentation lint. `cmake --build build --target doxygen-check` runs

--- a/fuzzer_entrypoints/curl_fuzzer_proto.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto.cc
@@ -6,10 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer = proto_fuzzer::ProtoFuzzerEntrypoint<
+    proto_fuzzer::TargetProfile::kCompatibility>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// historical mixed lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_api.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_api.cc
@@ -6,9 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Keep this entrypoint in a same-named source so Fuzz Introspector attributes
-// the API lifecycle lane independently from the protocol-focused proto lanes.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer =
+    proto_fuzzer::ProtoFuzzerEntrypoint<proto_fuzzer::TargetProfile::kApi>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// API lifecycle lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_ftp.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_ftp.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include "proto_fuzzer/fuzzer_main.h"
+
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer =
+    proto_fuzzer::ProtoFuzzerEntrypoint<proto_fuzzer::TargetProfile::kFastFtp>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// FTP lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
+                                      std::size_t size) {
+  return Fuzzer::TestOneInput(data, size);
+}

--- a/fuzzer_entrypoints/curl_fuzzer_proto_http.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_http.cc
@@ -6,10 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer =
+    proto_fuzzer::ProtoFuzzerEntrypoint<proto_fuzzer::TargetProfile::kFastHttp>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// fast HTTP lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_http_deep.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_http_deep.cc
@@ -6,10 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer =
+    proto_fuzzer::ProtoFuzzerEntrypoint<proto_fuzzer::TargetProfile::kDeepHttp>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// deep HTTP lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_https.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_https.cc
@@ -6,10 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer = proto_fuzzer::ProtoFuzzerEntrypoint<
+    proto_fuzzer::TargetProfile::kFastHttps>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// HTTPS lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_telnet.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_telnet.cc
@@ -6,10 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer = proto_fuzzer::ProtoFuzzerEntrypoint<
+    proto_fuzzer::TargetProfile::kFastTelnet>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// TELNET lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_tftp.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_tftp.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include "proto_fuzzer/fuzzer_main.h"
+
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer =
+    proto_fuzzer::ProtoFuzzerEntrypoint<proto_fuzzer::TargetProfile::kFastTftp>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// TFTP lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
+                                      std::size_t size) {
+  return Fuzzer::TestOneInput(data, size);
+}

--- a/fuzzer_entrypoints/curl_fuzzer_proto_timing.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_timing.cc
@@ -6,10 +6,36 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer =
+    proto_fuzzer::ProtoFuzzerEntrypoint<proto_fuzzer::TargetProfile::kTiming>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// timing and backpressure lane independently while the implementation remains
+// shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_ws.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_ws.cc
@@ -6,10 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer = proto_fuzzer::ProtoFuzzerEntrypoint<
+    proto_fuzzer::TargetProfile::kFastWebSocket>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// WebSocket lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/fuzzer_entrypoints/curl_fuzzer_proto_wss.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_wss.cc
@@ -6,10 +6,35 @@
 
 #include "proto_fuzzer/fuzzer_main.h"
 
-// Fuzz Introspector pairs a static profile with runtime coverage by target
-// basename. This literal, same-named entrypoint keeps that pairing precise
-// while all lanes continue to share protobuf mutation and scenario execution.
-extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t* data,
+namespace {
+
+// Bind this source's visible target identity once so mutation, crossover, and
+// execution cannot drift onto different policies as the shared runner evolves.
+using Fuzzer = proto_fuzzer::ProtoFuzzerEntrypoint<
+    proto_fuzzer::TargetProfile::kFastSecureWebSocket>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source. Besides making
+// the selected profile explicit, this lets Fuzz Introspector attribute the
+// secure WebSocket lane independently while the implementation remains shared.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
                                       std::size_t size) {
-  return proto_fuzzer::ProtoFuzzerTestOneInput(data, size);
+  return Fuzzer::TestOneInput(data, size);
 }

--- a/ossconfig/curl_fuzzer_proto_ftp.options
+++ b/ossconfig/curl_fuzzer_proto_ftp.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32768

--- a/ossconfig/curl_fuzzer_proto_tftp.options
+++ b/ossconfig/curl_fuzzer_proto_tftp.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32768

--- a/proto_fuzzer/ftp_mock_server.cc
+++ b/proto_fuzzer/ftp_mock_server.cc
@@ -1,0 +1,506 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+/// @file
+/// @brief Implementation of the command-aware in-process FTP peer.
+
+#include "proto_fuzzer/ftp_mock_server.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "proto_fuzzer/mock_server.h"
+#include "proto_fuzzer/scenario_limits.h"
+
+namespace proto_fuzzer {
+
+/// Begin without a borrowed protobuf or any open socketpairs. Keeping all
+/// session state in the object avoids process globals that could leak one
+/// libFuzzer iteration's protocol position into the next.
+FtpMockServer::FtpMockServer()
+    : scenario_(nullptr),
+      next_data_script_(0),
+      control_reply_count_(0),
+      next_control_reply_(0),
+      control_opened_(false) {}
+
+/// Loopback peers are ordinary unique_ptr-owned transports; the out-of-line
+/// destructor also permits MockConnection to remain forward-declared
+/// in the header.
+FtpMockServer::~FtpMockServer() = default;
+
+/// Return the bounded command capture accumulated by the most recent drive.
+const std::string& FtpMockServer::control_transcript() const { return control_transcript_; }
+
+/// Return the bounded upload capture accumulated by the most recent drive.
+const std::string& FtpMockServer::uploaded_data() const { return uploaded_data_; }
+
+/// Report how many passive peers curl actually requested, rather than how many
+/// scripts happened to be present in the protobuf.
+std::size_t FtpMockServer::opened_data_connection_count() const { return next_data_script_; }
+
+/// Clear descriptor and parser state before borrowing the next Scenario. A
+/// FtpMockServer can be reused serially, but no connection or response cursor
+/// is meaningful across easy-handle drives.
+void FtpMockServer::ResetForScenario(const curl::fuzzer::proto::Scenario& scenario) {
+  control_connection_.reset();
+  for (DataChannel& channel : data_channels_) {
+    channel.connection.reset();
+    channel.script = nullptr;
+    channel.transfer_started = false;
+    channel.upload = false;
+  }
+
+  scenario_ = &scenario;
+  next_data_script_ = 0;
+  control_reply_count_ = std::min<std::size_t>(scenario_limits::kMaxResponseChunks,
+                                               static_cast<std::size_t>(scenario.connection().on_readable_size()));
+  next_control_reply_ = 0;
+  pending_control_bytes_.clear();
+  control_transcript_.clear();
+  uploaded_data_.clear();
+  control_opened_ = false;
+}
+
+/// Clamp a compatibility input's raw protobuf socket size before crossing the
+/// platform int boundary. Target policies normally clear FTP backpressure,
+/// but direct corpus replay must retain deterministic, well-defined behavior.
+void FtpMockServer::ApplyScriptBackpressure(MockConnection* connection, const curl::fuzzer::proto::Connection& script) {
+  if (connection == nullptr) {
+    return;
+  }
+
+  const std::uint32_t int_max = static_cast<std::uint32_t>(std::numeric_limits<int>::max());
+  const auto& backpressure = script.backpressure();
+  const int receive_buffer = static_cast<int>(std::min(backpressure.recv_buf_bytes(), int_max));
+  connection->ApplyBackpressure(receive_buffer, static_cast<std::size_t>(backpressure.drain_limit()));
+}
+
+/// Allocate one control socket followed by a bounded sequence of passive data
+/// sockets. Data is intentionally not preloaded here: curl opens EPSV/PASV's
+/// socket before it has sent the command that determines whether the stream is
+/// a listing, download, or upload.
+/// @param purpose Socket role requested by curl; active-mode accepts are
+///                deliberately unsupported.
+/// @param address Original IP destination retained by curl for FTP's passive
+///                host selection; the connected socketpair need not alter it.
+/// @return An already-connected client fd, or CURL_SOCKET_BAD when the bounded
+///         control/data script has no matching peer.
+curl_socket_t FtpMockServer::HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) {
+  (void)address;
+  // Passive control/data sockets are ordinary outbound connections. Reject an
+  // active-mode accept request rather than handing curl a connected socketpair
+  // whose semantics cannot model listen/accept or a server callback.
+  if (scenario_ == nullptr || purpose != CURLSOCKTYPE_IPCXN) {
+    return CURL_SOCKET_BAD;
+  }
+
+  if (!control_opened_) {
+    control_connection_ = std::make_unique<MockConnection>();
+    if (!control_connection_->ok()) {
+      control_connection_.reset();
+      return CURL_SOCKET_BAD;
+    }
+
+    ApplyScriptBackpressure(control_connection_.get(), scenario_->connection());
+    const std::string& greeting = scenario_->connection().initial_response();
+    if (!greeting.empty() &&
+        !control_connection_->WriteAll(reinterpret_cast<const unsigned char*>(greeting.data()), greeting.size())) {
+      control_connection_.reset();
+      return CURL_SOCKET_BAD;
+    }
+    // Do not consume the unique control slot until its peer is usable. Curl
+    // may retry a failed application socket callback, and that retry must not
+    // be mistaken for the first passive data connection.
+    control_opened_ = true;
+    return control_connection_->take_client_fd();
+  }
+
+  const std::size_t available_scripts =
+      std::min<std::size_t>(kMaxDataChannels, static_cast<std::size_t>(scenario_->subsequent_connections_size()));
+  if (next_data_script_ >= available_scripts) {
+    return CURL_SOCKET_BAD;
+  }
+
+  DataChannel& channel = data_channels_[next_data_script_];
+  channel.script = &scenario_->subsequent_connections(static_cast<int>(next_data_script_));
+  channel.connection = std::make_unique<MockConnection>();
+  if (!channel.connection->ok()) {
+    channel.connection.reset();
+    channel.script = nullptr;
+    return CURL_SOCKET_BAD;
+  }
+
+  ApplyScriptBackpressure(channel.connection.get(), *channel.script);
+  ++next_data_script_;
+  return channel.connection->take_client_fd();
+}
+
+/// Retain only a bounded prefix for assertions. Parsing and draining continue
+/// against the full transport bytes, so reaching the cap cannot change curl's
+/// behavior or manufacture socket backpressure.
+void FtpMockServer::CapturePrefix(std::string_view source, std::size_t limit, std::string* destination) {
+  if (destination == nullptr || destination->size() >= limit) {
+    return;
+  }
+  const std::size_t available = limit - destination->size();
+  destination->append(source.data(), std::min(source.size(), available));
+}
+
+/// Remove FTP's optional leading horizontal whitespace and return just the
+/// verb. Arguments remain untouched because only curl, not the mock harness,
+/// should interpret fuzzed paths and offsets.
+std::string_view FtpMockServer::CommandVerb(std::string_view command) {
+  std::size_t begin = 0;
+  while (begin < command.size() && (command[begin] == ' ' || command[begin] == '\t')) {
+    ++begin;
+  }
+
+  std::size_t end = begin;
+  while (end < command.size() && command[end] != ' ' && command[end] != '\t' && command[end] != '\r' &&
+         command[end] != '\n') {
+    ++end;
+  }
+  return command.substr(begin, end - begin);
+}
+
+/// Fold only ASCII lowercase command letters. FTP verbs are ASCII tokens, so
+/// locale-aware case conversion would add state and undefined signed-char
+/// behavior without accepting anything curl can legitimately send.
+bool FtpMockServer::VerbEquals(std::string_view verb, std::string_view expected_uppercase) {
+  if (verb.size() != expected_uppercase.size()) {
+    return false;
+  }
+  for (std::size_t index = 0; index < verb.size(); ++index) {
+    unsigned char actual = static_cast<unsigned char>(verb[index]);
+    if (actual >= 'a' && actual <= 'z') {
+      actual = static_cast<unsigned char>(actual - 'a' + 'A');
+    }
+    if (actual != static_cast<unsigned char>(expected_uppercase[index])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Recognize curl's built-in data commands plus MLSD, the useful structured
+/// listing custom request. PRET deliberately remains control-only even though
+/// its argument can contain RETR/STOR: no data transfer has begun at that
+/// point.
+FtpMockServer::TransferDirection FtpMockServer::DirectionForVerb(std::string_view verb) {
+  if (VerbEquals(verb, "STOR") || VerbEquals(verb, "APPE")) {
+    return TransferDirection::kUpload;
+  }
+  if (VerbEquals(verb, "RETR") || VerbEquals(verb, "LIST") || VerbEquals(verb, "NLST") || VerbEquals(verb, "MLSD")) {
+    return TransferDirection::kDownload;
+  }
+  return TransferDirection::kNone;
+}
+
+/// Scan backwards because repeated setopt calls are legal and libcurl keeps
+/// the last value. Comparing only the verb preserves arbitrary custom
+/// arguments while still avoiding false positives on preparatory FTP commands
+/// that happen to receive a fuzzed 125/150 reply after EPSV opened a socket.
+bool FtpMockServer::IsConfiguredCustomDownload(std::string_view verb) const {
+  if (scenario_ == nullptr || verb.empty()) {
+    return false;
+  }
+
+  for (int index = scenario_->options_size() - 1; index >= 0; --index) {
+    const auto& option = scenario_->options(index);
+    if (option.option_id() != curl::fuzzer::proto::CURLOPT_CUSTOMREQUEST) {
+      continue;
+    }
+    if (option.value_case() != curl::fuzzer::proto::SetOption::kStringValue) {
+      return false;
+    }
+    return VerbEquals(verb, CommandVerb(option.string_value()));
+  }
+  return false;
+}
+
+/// Scan complete lines because a legal FTP response fragment may start with
+/// one or more informational lines. curl ends a response at the first line
+/// whose first three bytes are digits and whose fourth byte is a space.
+int FtpMockServer::FirstReplyCode(std::string_view response) {
+  std::size_t line_start = 0;
+  while (line_start < response.size()) {
+    const std::size_t newline = response.find('\n', line_start);
+    if (newline == std::string_view::npos) {
+      return -1;
+    }
+    const std::size_t line_size = newline - line_start + 1;
+    if (line_size > 3) {
+      const unsigned char first = static_cast<unsigned char>(response[line_start]);
+      const unsigned char second = static_cast<unsigned char>(response[line_start + 1]);
+      const unsigned char third = static_cast<unsigned char>(response[line_start + 2]);
+      if (first >= '0' && first <= '9' && second >= '0' && second <= '9' && third >= '0' && third <= '9' &&
+          response[line_start + 3] == ' ') {
+        return 100 * (first - '0') + 10 * (second - '0') + (third - '0');
+      }
+    }
+    line_start = newline + 1;
+  }
+  return -1;
+}
+
+/// A raw completion such as "226 done" needs only its missing newline. In
+/// that common mutation, appending a second synthetic reply would leave bytes
+/// in curl's control cache and misalign a later wildcard transfer.
+bool FtpMockServer::TailNeedsOnlyNewline(std::string_view response) {
+  const std::size_t last_newline = response.rfind('\n');
+  const std::size_t tail = last_newline == std::string_view::npos ? 0 : last_newline + 1;
+  if (response.size() - tail <= 3) {
+    return false;
+  }
+  const unsigned char first = static_cast<unsigned char>(response[tail]);
+  const unsigned char second = static_cast<unsigned char>(response[tail + 1]);
+  const unsigned char third = static_cast<unsigned char>(response[tail + 2]);
+  return first >= '0' && first <= '9' && second >= '0' && second <= '9' && third >= '0' && third <= '9' &&
+         response[tail + 3] == ' ';
+}
+
+/// Return the next bounded primary response. Empty strings still advance the
+/// cursor: they are meaningful truncation mutations for ordinary command
+/// states and explicitly select control EOF at transfer completion.
+const std::string* FtpMockServer::NextControlReply() {
+  if (scenario_ == nullptr || next_control_reply_ >= control_reply_count_) {
+    return nullptr;
+  }
+  return &scenario_->connection().on_readable(static_cast<int>(next_control_reply_++));
+}
+
+/// Keep failed peer writes local to the mock. Response cursors must still
+/// advance after curl closes early, otherwise a replacement socket could see
+/// a reply intended for an earlier command.
+bool FtpMockServer::WriteControlBytes(std::string_view bytes) {
+  return bytes.empty() ||
+         (control_connection_ != nullptr &&
+          control_connection_->WriteAll(reinterpret_cast<const unsigned char*>(bytes.data()), bytes.size()));
+}
+
+/// Queue a scenario-provided final reply and make it guaranteed non-blocking.
+/// ftp_done_control_reply() calls getftpresponse() synchronously after data
+/// EOF; if the fuzzed fragment lacks a terminating numeric line, append the
+/// smallest completion needed so curl returns to the harness immediately. An
+/// explicitly empty repeated value instead half-closes the peer: this retains
+/// deterministic liveness while making curl's missing-completion error path
+/// directly seedable.
+void FtpMockServer::QueueTransferCompletion() {
+  const std::string* response = NextControlReply();
+  if (response != nullptr && response->empty()) {
+    if (control_connection_ != nullptr) {
+      control_connection_->ShutdownWrite();
+    }
+    return;
+  }
+  if (response != nullptr && !response->empty()) {
+    (void)WriteControlBytes(*response);
+    if (FirstReplyCode(*response) >= 0) {
+      return;
+    }
+    if (TailNeedsOnlyNewline(*response)) {
+      (void)WriteControlBytes("\r\n");
+      return;
+    }
+    if (response->back() != '\n') {
+      (void)WriteControlBytes("\r\n");
+    }
+  }
+
+  // This line is a liveness guard, not a forced successful outcome: any
+  // complete fuzzed final response above remains the reply curl consumes.
+  (void)WriteControlBytes("226 mock transfer complete\r\n");
+}
+
+/// Send every runtime-visible data fragment before half-closing the peer. The
+/// serialized fuzz input is already length-bounded; sending the complete
+/// prefix lets curl drain its data state without event-loop sleeps while each
+/// protobuf fragment still affects byte content and parser behavior.
+void FtpMockServer::PreloadDownload(DataChannel* channel) {
+  if (channel == nullptr || channel->connection == nullptr || channel->script == nullptr) {
+    return;
+  }
+
+  const std::string& initial = channel->script->initial_response();
+  bool complete = initial.empty() ||
+                  channel->connection->WriteAll(reinterpret_cast<const unsigned char*>(initial.data()), initial.size());
+  const std::size_t chunk_count = std::min<std::size_t>(scenario_limits::kMaxResponseChunks,
+                                                        static_cast<std::size_t>(channel->script->on_readable_size()));
+  for (std::size_t index = 0; complete && index < chunk_count; ++index) {
+    const std::string& chunk = channel->script->on_readable(static_cast<int>(index));
+    complete = chunk.empty() ||
+               channel->connection->WriteAll(reinterpret_cast<const unsigned char*>(chunk.data()), chunk.size());
+  }
+  (void)complete;
+  channel->connection->ShutdownWrite();
+}
+
+/// Pair the next transfer command with the oldest passive socket that EPSV or
+/// PASV opened but no command has used. FTP serializes data transfers, so this
+/// simple cursor is sufficient and avoids interpreting fuzzed port numbers.
+void FtpMockServer::StartNextTransfer(TransferDirection direction) {
+  for (std::size_t index = 0; index < next_data_script_; ++index) {
+    DataChannel& channel = data_channels_[index];
+    if (channel.connection == nullptr || channel.transfer_started) {
+      continue;
+    }
+
+    channel.transfer_started = true;
+    channel.upload = direction == TransferDirection::kUpload;
+    if (!channel.upload) {
+      PreloadDownload(&channel);
+    }
+    // Upload peers keep their write half open until cleanup. A real FTP server
+    // does not send an early FIN while receiving a file, and a readiness
+    // backend could otherwise report that FIN alongside POLLOUT before curl
+    // has delivered the upload callback's bytes.
+    return;
+  }
+}
+
+/// Advance one reply for every complete command. Accepted transfer commands
+/// additionally consume their final reply now, because waiting until data EOF
+/// would be too late to escape curl's blocking completion read.
+void FtpMockServer::HandleControlCommand(std::string_view command) {
+  const std::string* response = NextControlReply();
+  if (response == nullptr) {
+    return;
+  }
+
+  const int response_code = FirstReplyCode(*response);
+  (void)WriteControlBytes(*response);
+
+  const std::string_view verb = CommandVerb(command);
+  TransferDirection direction = DirectionForVerb(verb);
+  if (direction == TransferDirection::kNone && IsConfiguredCustomDownload(verb)) {
+    direction = TransferDirection::kDownload;
+  }
+  const bool starts_download =
+      direction == TransferDirection::kDownload && (response_code == 125 || response_code == 150);
+  // curl's STOR handler accepts every response below 400 before initiating
+  // the upload, even though 125/150 are the conventional successful replies.
+  const bool starts_upload = direction == TransferDirection::kUpload && response_code >= 100 && response_code < 400;
+  if (starts_download || starts_upload) {
+    StartNextTransfer(direction);
+    QueueTransferCompletion();
+  }
+}
+
+/// Read without waiting, retain partial final commands, and process all full
+/// lines already emitted by curl. The number of replies is bounded even if a
+/// malformed command stream contains many newlines.
+bool FtpMockServer::ServiceControlConnection() {
+  if (control_connection_ == nullptr) {
+    return false;
+  }
+
+  const std::size_t size_before_read = pending_control_bytes_.size();
+  control_connection_->ReadAvailable(&pending_control_bytes_);
+  bool made_progress = pending_control_bytes_.size() != size_before_read;
+
+  std::size_t consumed = 0;
+  while (consumed < pending_control_bytes_.size()) {
+    const std::size_t newline = pending_control_bytes_.find('\n', consumed);
+    if (newline == std::string::npos) {
+      break;
+    }
+    const std::size_t command_size = newline - consumed + 1;
+    const std::string_view command(pending_control_bytes_.data() + consumed, command_size);
+    CapturePrefix(command, kMaxCapturedControlBytes, &control_transcript_);
+    HandleControlCommand(command);
+    consumed += command_size;
+    made_progress = true;
+  }
+
+  if (consumed != 0) {
+    pending_control_bytes_.erase(0, consumed);
+  }
+  return made_progress;
+}
+
+/// Drain uploads into a temporary buffer so data beyond the observable cap is
+/// still removed from the socket. This keeps curl's progress independent of
+/// how much a unit test chooses to retain.
+bool FtpMockServer::ServiceUploadConnections() {
+  bool made_progress = false;
+  for (std::size_t index = 0; index < next_data_script_; ++index) {
+    DataChannel& channel = data_channels_[index];
+    if (!channel.upload || channel.connection == nullptr) {
+      continue;
+    }
+
+    std::string bytes;
+    channel.connection->ReadAvailable(&bytes);
+    if (!bytes.empty()) {
+      CapturePrefix(bytes, kMaxCapturedUploadBytes, &uploaded_data_);
+      made_progress = true;
+    }
+  }
+  return made_progress;
+}
+
+/// Prepare cleanup while the mock can still write to curl's control socket.
+/// A completed easy remains in multi's connection cache until cleanup, where
+/// FTP sends QUIT and performs a blocking read. Preloading 221 handles that
+/// path; an unfinished drive instead gets EOF so cleanup fails fast.
+void FtpMockServer::FinishConnections(bool completed) {
+  if (control_connection_ != nullptr) {
+    if (completed) {
+      (void)WriteControlBytes("221 mock closing control connection\r\n");
+    }
+    control_connection_->ShutdownWrite();
+  }
+  for (std::size_t index = 0; index < next_data_script_; ++index) {
+    if (data_channels_[index].connection != nullptr) {
+      data_channels_[index].connection->ShutdownWrite();
+    }
+  }
+}
+
+/// Alternate curl transitions with immediate peer service until the transfer
+/// completes or deterministic idle/operation caps win. No select(), poll(),
+/// or sleep is needed: every transport is a local socketpair, and malformed
+/// scripts are terminated by half-close after the bounded loop.
+void FtpMockServer::RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) {
+  (void)easy;
+  ResetForScenario(scenario);
+
+  int still_running = 1;
+  int idle_iterations = 0;
+  int drive_iterations = 0;
+  CURLMcode result = CURLM_OK;
+  while (still_running && idle_iterations < kMaxIdleIterations && drive_iterations++ < kMaxDriveIterations) {
+    const int running_before = still_running;
+    result = curl_multi_perform(multi, &still_running);
+    if (result != CURLM_OK) {
+      break;
+    }
+
+    bool made_progress = still_running != running_before;
+    made_progress = ServiceControlConnection() || made_progress;
+    made_progress = ServiceUploadConnections() || made_progress;
+    if (made_progress) {
+      idle_iterations = 0;
+    } else {
+      ++idle_iterations;
+    }
+  }
+
+  // The final perform may have emitted upload or control bytes immediately
+  // before marking the transfer done. Drain/capture them before cleanup.
+  (void)ServiceControlConnection();
+  (void)ServiceUploadConnections();
+  FinishConnections(still_running == 0 && result == CURLM_OK);
+  scenario_ = nullptr;
+}
+
+}  // namespace proto_fuzzer

--- a/proto_fuzzer/ftp_mock_server.h
+++ b/proto_fuzzer/ftp_mock_server.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+/// @file
+/// @brief Command-aware in-process peer for curl's FTP state machine.
+
+#ifndef PROTO_FUZZER_FTP_MOCK_SERVER_H_
+#define PROTO_FUZZER_FTP_MOCK_SERVER_H_
+
+#include <curl/curl.h>
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "curl_fuzzer.pb.h"
+#include "proto_fuzzer/mock_server_base.h"
+#include "proto_fuzzer/scenario_limits.h"
+
+namespace proto_fuzzer {
+
+/// @class proto_fuzzer::FtpMockServer
+/// @brief Keeps FTP's control and passive-data connections alive together.
+///
+/// FTP cannot use the generic one-script-per-socket HTTP peer: curl opens a
+/// passive data socket while it still needs the control socket for TYPE,
+/// SIZE, RETR/STOR, and the final transfer reply. This peer therefore treats
+/// Scenario.connection as a command-aligned control script and the bounded
+/// subsequent_connections prefix as passive data streams. All work remains
+/// in-process and non-waiting so malformed scripts terminate by operation
+/// budget or EOF rather than by curl's FTP response timeout.
+class FtpMockServer final : public MockServerBase {
+ public:
+  /// Construct an idle server. RunLoop borrows a Scenario only for the
+  /// synchronous DriveScenario call in which socket callbacks can run.
+  FtpMockServer();
+
+  /// Release every socketpair peer after curl has returned its client fds.
+  ~FtpMockServer() override;
+
+  /// Expose commands sent by curl so tests can verify that a seed reached the
+  /// intended FTP states without coupling assertions to curl debug output.
+  /// The capture is bounded independently of protocol processing.
+  /// @return A prefix of complete control commands, including line endings.
+  const std::string& control_transcript() const;
+
+  /// Expose a bounded prefix of uploaded data while continuing to drain all
+  /// client bytes, preventing test observability from creating backpressure.
+  /// @return Bytes curl sent over passive upload connections.
+  const std::string& uploaded_data() const;
+
+  /// Let tests distinguish control-only failures from paths that reached
+  /// curl's passive connection setup.
+  /// @return Number of bounded passive socketpairs handed to curl.
+  std::size_t opened_data_connection_count() const;
+
+ protected:
+  /// Assign the first socket to the control script and later sockets to at
+  /// most three passive data scripts. The callback arguments are deliberately
+  /// ignored: FTPPORT is excluded by target policy, while socketpairs are
+  /// already connected for both EPSV and PASV paths.
+  curl_socket_t HandleOpenSocket(curlsocktype purpose = CURLSOCKTYPE_IPCXN,
+                                 struct curl_sockaddr* address = nullptr) override;
+
+  /// Drive curl and the command-aware peer in alternating, bounded turns.
+  /// @param multi Multi handle containing `easy`.
+  /// @param easy Easy handle already installed on this mock.
+  /// @param scenario Control and passive-data scripts to borrow.
+  void RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) override;
+
+ private:
+  /// Direction determines whether a passive peer should be preloaded and
+  /// half-closed for a download or kept readable while curl uploads to it.
+  enum class TransferDirection {
+    kNone,
+    kDownload,
+    kUpload,
+  };
+
+  /// One passive socket and its borrowed script must outlive the control
+  /// command that starts it. A fixed array keeps protobuf repetition from
+  /// turning into an unbounded collection of live descriptors.
+  struct DataChannel {
+    /// Scenario-owned bytes remain stable throughout the synchronous drive.
+    const curl::fuzzer::proto::Connection* script = nullptr;
+    /// The server half stays owned after curl receives the client fd.
+    std::unique_ptr<MockConnection> connection;
+    /// EPSV/PASV may open the socket well before RETR/STOR makes data valid.
+    bool transfer_started = false;
+    /// Upload peers are drained on every outer-loop turn.
+    bool upload = false;
+  };
+
+  /// Reset every borrowed pointer, descriptor, cursor, and observable capture
+  /// before a new drive so reusing a server cannot join two FTP sessions.
+  void ResetForScenario(const curl::fuzzer::proto::Scenario& scenario);
+
+  /// Apply a script's bounded transport knobs when its socket is created.
+  /// This mirrors the generic peer for compatibility inputs without allowing
+  /// narrowing of an arbitrary protobuf uint32 into a negative socket size.
+  static void ApplyScriptBackpressure(MockConnection* connection, const curl::fuzzer::proto::Connection& script);
+
+  /// Read all presently available control bytes and answer each complete
+  /// command with exactly one scripted fragment.
+  /// @return true when bytes or a command/reply cursor advanced.
+  bool ServiceControlConnection();
+
+  /// Drain every active upload socket even after the capture prefix is full.
+  /// @return true when curl produced at least one data byte.
+  bool ServiceUploadConnections();
+
+  /// Consume and dispatch one complete FTP command. Responses stay aligned
+  /// to commands rather than perform calls, which are not protocol events.
+  /// @param command One newline-terminated command from curl.
+  void HandleControlCommand(std::string_view command);
+
+  /// Select the next unopened passive peer and prepare it for the transfer.
+  /// @param direction Whether curl will read or write the data connection.
+  void StartNextTransfer(TransferDirection direction);
+
+  /// Preload all bounded download fragments once RETR/LIST has been accepted.
+  /// Delaying until the command prevents an early EOF from perturbing curl's
+  /// passive setup states.
+  /// @param channel Passive peer whose script supplies the download bytes.
+  void PreloadDownload(DataChannel* channel);
+
+  /// Queue the transfer-final response before curl observes data EOF. curl's
+  /// FTP completion path performs a blocking control read inside
+  /// curl_multi_perform, so the outer mock loop cannot provide this reply
+  /// afterwards.
+  void QueueTransferCompletion();
+
+  /// Return the next command-aligned control fragment within the shared
+  /// response-count budget.
+  /// @return Scenario-owned reply, or nullptr after the bounded prefix.
+  const std::string* NextControlReply();
+
+  /// Write raw control bytes while treating a peer race as an ordinary failed
+  /// mock write rather than a reason to alter protocol cursors.
+  /// @param bytes Response fragment to queue.
+  /// @return true when the complete fragment was queued.
+  bool WriteControlBytes(std::string_view bytes);
+
+  /// Extract the command verb without allocating, retaining arbitrary command
+  /// arguments for curl while limiting mock interpretation to routing.
+  /// @param command Complete command line.
+  /// @return View of its first non-whitespace token.
+  static std::string_view CommandVerb(std::string_view command);
+
+  /// Compare an arbitrary verb to an ASCII FTP command independent of curl's
+  /// chosen letter case and without locale-dependent transformations.
+  /// @param verb Parsed command token.
+  /// @param expected_uppercase Literal uppercase command name.
+  /// @return true when the verbs are equal ignoring ASCII case.
+  static bool VerbEquals(std::string_view verb, std::string_view expected_uppercase);
+
+  /// Recognize only commands that make curl use its secondary socket. Keeping
+  /// PRET and setup commands out is essential because their replies precede,
+  /// rather than complete, a data transfer.
+  /// @param verb Parsed FTP command verb.
+  /// @return transfer direction, or kNone for control-only commands.
+  static TransferDirection DirectionForVerb(std::string_view verb);
+
+  /// Recognize the last CURLOPT_CUSTOMREQUEST value as a data command. Curl
+  /// uses this option in place of LIST, so the peer must not require mutations
+  /// to rediscover one of its small built-in verb allowlist before releasing
+  /// the passive payload.
+  /// @param verb Parsed command token sent by curl.
+  /// @return true when verb matches the effective custom request option.
+  bool IsConfiguredCustomDownload(std::string_view verb) const;
+
+  /// Find the first complete numeric FTP response in a raw fragment. curl may
+  /// accept informational lines before it, so inspecting only byte zero would
+  /// fail to start data for otherwise valid scripts.
+  /// @param response Raw control fragment.
+  /// @return numeric status, or -1 when no terminating line is present.
+  static int FirstReplyCode(std::string_view response);
+
+  /// Detect a truncated but otherwise valid status line at the response tail.
+  /// Appending only CRLF in this case avoids leaving a synthetic reply queued
+  /// for a later wildcard transfer.
+  /// @param response Raw control fragment.
+  /// @return true when the unterminated tail begins with "ddd ".
+  static bool TailNeedsOnlyNewline(std::string_view response);
+
+  /// Bound transcript and upload observability separately from the bytes that
+  /// must still be parsed or drained to keep curl moving.
+  /// @param source Newly observed bytes.
+  /// @param limit Maximum retained destination size.
+  /// @param destination Capture buffer receiving the available prefix.
+  static void CapturePrefix(std::string_view source, std::size_t limit, std::string* destination);
+
+  /// Make cleanup non-blocking by preloading QUIT's 221 reply after a complete
+  /// transfer, or by exposing immediate EOF after an incomplete drive.
+  /// @param completed Whether curl reported that the transfer stopped.
+  void FinishConnections(bool completed);
+
+  /// Three passive sockets cover listing plus two file transfers while
+  /// matching the repository-wide four-connection scenario budget.
+  static constexpr std::size_t kMaxDataChannels = scenario_limits::kMaxConnections - 1;
+
+  /// Observability must not grow with a future curl command loop; these caps
+  /// exceed current normalized URL/upload budgets without affecting protocol
+  /// processing or socket draining.
+  static constexpr std::size_t kMaxCapturedControlBytes = 64 * 1024;
+  static constexpr std::size_t kMaxCapturedUploadBytes = 2 * scenario_limits::kMaxUploadBytes;
+
+  /// Borrowed only while RunLoop is active, including every socket callback.
+  const curl::fuzzer::proto::Scenario* scenario_;
+  /// Curl records the callback's original IP destination before accepting our
+  /// already-connected descriptor, so an AF_UNIX pair can drive EPSV/PASV
+  /// without paying for a TCP handshake on every fuzz iteration.
+  std::unique_ptr<MockConnection> control_connection_;
+  /// Fixed passive peer storage keeps control and data descriptors concurrent.
+  std::array<DataChannel, kMaxDataChannels> data_channels_;
+  /// Number of subsequent scripts already assigned to curl-opened sockets.
+  std::size_t next_data_script_;
+  /// Runtime-visible prefix of primary on_readable response fragments.
+  std::size_t control_reply_count_;
+  /// Cursor advanced once per command, plus once per accepted transfer final.
+  std::size_t next_control_reply_;
+  /// Partial command bytes retained until curl supplies a newline.
+  std::string pending_control_bytes_;
+  /// Bounded test-facing record of complete commands sent by curl.
+  std::string control_transcript_;
+  /// Bounded test-facing prefix of bytes drained from upload peers.
+  std::string uploaded_data_;
+  /// Prevent a second control socket from displacing the live first one.
+  bool control_opened_;
+};
+
+}  // namespace proto_fuzzer
+
+#endif  // PROTO_FUZZER_FTP_MOCK_SERVER_H_

--- a/proto_fuzzer/fuzzer_main.cc
+++ b/proto_fuzzer/fuzzer_main.cc
@@ -12,6 +12,7 @@
 #include <curl/curl.h>
 #include <libprotobuf-mutator/src/libfuzzer/libfuzzer_macro.h>
 
+#include <cassert>
 #include <csignal>
 
 #include "curl_fuzzer.pb.h"
@@ -23,49 +24,35 @@ namespace {
 
 constexpr bool kUseBinaryFormat = true;
 
-/// Return the one profile compiled into this binary. Keeping target selection
-/// behind a function avoids accumulating namespace-scope behaviour flags; all
-/// mutation and execution choices are derived from this identity.
-constexpr proto_fuzzer::TargetProfile CompiledTargetProfile() {
-#if defined(PROTO_FUZZER_TARGET_COMPATIBILITY)
-  // The original target deliberately has no mutation policy. Its OSS-Fuzz
-  // corpus contains mixed schemes and timing controls whose semantics must
-  // remain stable across the target split.
-  return proto_fuzzer::TargetProfile::kCompatibility;
-#elif defined(PROTO_FUZZER_TARGET_FAST_HTTP)
-  return proto_fuzzer::TargetProfile::kFastHttp;
-#elif defined(PROTO_FUZZER_TARGET_DEEP_HTTP)
-  return proto_fuzzer::TargetProfile::kDeepHttp;
-#elif defined(PROTO_FUZZER_TARGET_FAST_HTTPS)
-  return proto_fuzzer::TargetProfile::kFastHttps;
-#elif defined(PROTO_FUZZER_TARGET_FAST_WEBSOCKET)
-  return proto_fuzzer::TargetProfile::kFastWebSocket;
-#elif defined(PROTO_FUZZER_TARGET_FAST_SECURE_WEBSOCKET)
-  return proto_fuzzer::TargetProfile::kFastSecureWebSocket;
-#elif defined(PROTO_FUZZER_TARGET_FAST_TELNET)
-  return proto_fuzzer::TargetProfile::kFastTelnet;
-#elif defined(PROTO_FUZZER_TARGET_API)
-  return proto_fuzzer::TargetProfile::kApi;
-#elif defined(PROTO_FUZZER_TARGET_TIMING)
-  return proto_fuzzer::TargetProfile::kTiming;
-#else
-#error "A proto fuzzer target profile must be selected"
-#endif
-}
+/// Register the fixed lane's normalizer before asking LPM to parse or mutate
+/// its first input. LoadProtoInput runs LPM's Fix() only for direct corpus
+/// loads; a just-mutated input is recovered from LPM's cache and has already
+/// passed the same postprocessor. Ordering the registration here therefore
+/// covers both paths without normalizing cached mutations twice.
+///
+/// One libFuzzer process exposes exactly one entrypoint and therefore one
+/// profile. Capturing the first profile lets the shared runtime use LPM's
+/// process-wide postprocessor registry without hiding target selection in a
+/// compiler definition. The compatibility target deliberately registers
+/// nothing, preserving its historical mixed-corpus mutation semantics.
+void EnsureTargetPostProcessor(proto_fuzzer::TargetProfile profile) {
+  if (profile == proto_fuzzer::TargetProfile::kCompatibility) {
+    return;
+  }
 
-#if !defined(PROTO_FUZZER_TARGET_COMPATIBILITY)
-/// Restore the target's protocol and timing invariants after every mutation.
-/// Registering this during static initialization matters: corpus inputs pass
-/// through LPM's Fix() before the first fuzz callback, so a function-local
-/// registration would let the first input bypass the target policy.
-void PostProcessScenario(curl::fuzzer::proto::Scenario* scenario, unsigned int /*seed*/) {
-  proto_fuzzer::ApplyTargetPolicy(scenario, CompiledTargetProfile());
-  proto_fuzzer::CanonicalizeOptionValueCases(scenario);
-}
+  static const proto_fuzzer::TargetProfile registered_profile = profile;
+  static const protobuf_mutator::libfuzzer::PostProcessorRegistration<curl::fuzzer::proto::Scenario>
+      policy_registration([](curl::fuzzer::proto::Scenario* scenario, unsigned int /*seed*/) {
+        proto_fuzzer::ApplyTargetPolicy(scenario, registered_profile);
+        proto_fuzzer::CanonicalizeOptionValueCases(scenario);
+      });
 
-const protobuf_mutator::libfuzzer::PostProcessorRegistration<curl::fuzzer::proto::Scenario> kPolicyRegistration(
-    &PostProcessScenario);
-#endif
+  // A second profile in one process would cause LPM's global registry to
+  // enforce the wrong lane. Real fuzz binaries cannot do this; keep the
+  // assertion to make misuse by future in-process callers immediately clear.
+  assert(profile == registered_profile);
+  (void)policy_registration;
+}
 
 // Wire curl_global_init once so repeated fuzz iterations don't pay for it on every call. libFuzzer reuses the process;
 // static ctors run once.
@@ -83,45 +70,30 @@ const CurlGlobalBootstrap kGlobalBootstrap;
 
 }  // namespace
 
-/// Mutate a binary Scenario through LPM. This symbol deliberately remains in
-/// the shared implementation: mutation policy is identical within one binary,
-/// while only the test entrypoint needs a unique source basename for static
-/// coverage attribution.
-/// @param data Mutable serialized Scenario storage.
-/// @param size Current serialized size.
-/// @param max_size Capacity of data.
-/// @param seed Mutation random seed supplied by libFuzzer.
-/// @return Serialized size after mutation.
-extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t* data, std::size_t size, std::size_t max_size,
-                                               unsigned int seed) {
+namespace proto_fuzzer {
+
+std::size_t ProtoFuzzerCustomMutator(TargetProfile profile, std::uint8_t* data, std::size_t size, std::size_t max_size,
+                                     unsigned int seed) {
+  EnsureTargetPostProcessor(profile);
   curl::fuzzer::proto::Scenario scenario;
   return protobuf_mutator::libfuzzer::CustomProtoMutator(kUseBinaryFormat, data, size, max_size, seed, &scenario);
 }
 
-/// Cross two binary Scenarios through LPM while preserving target policy.
-/// @param data1 First serialized parent.
-/// @param size1 Size of data1.
-/// @param data2 Second serialized parent.
-/// @param size2 Size of data2.
-/// @param out Destination storage.
-/// @param max_out_size Capacity of out.
-/// @param seed Crossover random seed supplied by libFuzzer.
-/// @return Serialized child size.
-extern "C" std::size_t LLVMFuzzerCustomCrossOver(const std::uint8_t* data1, std::size_t size1,
-                                                 const std::uint8_t* data2, std::size_t size2, std::uint8_t* out,
-                                                 std::size_t max_out_size, unsigned int seed) {
+std::size_t ProtoFuzzerCustomCrossOver(TargetProfile profile, const std::uint8_t* data1, std::size_t size1,
+                                       const std::uint8_t* data2, std::size_t size2, std::uint8_t* out,
+                                       std::size_t max_out_size, unsigned int seed) {
+  EnsureTargetPostProcessor(profile);
   curl::fuzzer::proto::Scenario scenario1;
   curl::fuzzer::proto::Scenario scenario2;
   return protobuf_mutator::libfuzzer::CustomProtoCrossOver(kUseBinaryFormat, data1, size1, data2, size2, out,
                                                            max_out_size, seed, &scenario1, &scenario2);
 }
 
-namespace proto_fuzzer {
-
-int ProtoFuzzerTestOneInput(const std::uint8_t* data, std::size_t size) {
+int ProtoFuzzerTestOneInput(TargetProfile profile, const std::uint8_t* data, std::size_t size) {
+  EnsureTargetPostProcessor(profile);
   curl::fuzzer::proto::Scenario scenario;
   if (protobuf_mutator::libfuzzer::LoadProtoInput(kUseBinaryFormat, data, size, &scenario)) {
-    ScenarioRunner().Run(scenario, RunModeFor(CompiledTargetProfile()));
+    ScenarioRunner().Run(scenario, RunModeFor(profile));
   }
   return 0;
 }

--- a/proto_fuzzer/fuzzer_main.h
+++ b/proto_fuzzer/fuzzer_main.h
@@ -13,15 +13,88 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "proto_fuzzer/target_profile.h"
+
 namespace proto_fuzzer {
 
 /// Decode and run one serialized Scenario. Keeping this behind an ordinary
 /// function allows each binary to expose a discoverable, same-named libFuzzer
-/// entrypoint while retaining one mutation and execution implementation.
+/// entrypoint while retaining one mutation and execution implementation. The
+/// profile is explicit so target identity remains visible at the entrypoint
+/// instead of being hidden in per-translation-unit compiler definitions.
+/// @param profile Mutation and execution policy selected by the entrypoint.
 /// @param data Serialized binary Scenario bytes.
 /// @param size Number of bytes available at data.
 /// @return Always zero, as required by libFuzzer.
-int ProtoFuzzerTestOneInput(const std::uint8_t* data, std::size_t size);
+int ProtoFuzzerTestOneInput(TargetProfile profile, const std::uint8_t* data, std::size_t size);
+
+/// Mutate a serialized Scenario while preserving the selected lane's policy.
+/// @param profile Mutation and execution policy selected by the entrypoint.
+/// @param data Mutable serialized Scenario storage.
+/// @param size Current serialized size.
+/// @param max_size Capacity of data.
+/// @param seed Mutation random seed supplied by libFuzzer.
+/// @return Serialized size after mutation.
+std::size_t ProtoFuzzerCustomMutator(TargetProfile profile, std::uint8_t* data, std::size_t size, std::size_t max_size,
+                                     unsigned int seed);
+
+/// Cross two serialized Scenarios while preserving the selected lane's policy.
+/// @param profile Mutation and execution policy selected by the entrypoint.
+/// @param data1 First serialized parent.
+/// @param size1 Size of data1.
+/// @param data2 Second serialized parent.
+/// @param size2 Size of data2.
+/// @param out Destination storage.
+/// @param max_out_size Capacity of out.
+/// @param seed Crossover random seed supplied by libFuzzer.
+/// @return Serialized child size.
+std::size_t ProtoFuzzerCustomCrossOver(TargetProfile profile, const std::uint8_t* data1, std::size_t size1,
+                                       const std::uint8_t* data2, std::size_t size2, std::uint8_t* out,
+                                       std::size_t max_out_size, unsigned int seed);
+
+/// Binds a concrete profile once in each thin entrypoint source. This adapter
+/// keeps libFuzzer's C ABI boilerplate uniform without making target selection
+/// an invisible compile-time side effect in the shared implementation.
+/// @tparam Profile Fixed identity of the binary exposing these callbacks.
+template <TargetProfile Profile>
+struct ProtoFuzzerEntrypoint {
+  /// Forward a corpus input with the profile fixed by this binary. Keeping the
+  /// profile out of the C ABI prevents libFuzzer from choosing it while still
+  /// making the binding explicit in the entrypoint source.
+  /// @param data Serialized binary Scenario bytes.
+  /// @param size Number of bytes available at data.
+  /// @return Always zero, as required by libFuzzer.
+  static int TestOneInput(const std::uint8_t* data, std::size_t size) {
+    return ProtoFuzzerTestOneInput(Profile, data, size);
+  }
+
+  /// Forward mutation through the same fixed profile used for execution so a
+  /// lane cannot accumulate inputs that its runner will immediately discard.
+  /// @param data Mutable serialized Scenario storage.
+  /// @param size Current serialized size.
+  /// @param max_size Capacity of data.
+  /// @param seed Mutation random seed supplied by libFuzzer.
+  /// @return Serialized size after mutation.
+  static std::size_t CustomMutator(std::uint8_t* data, std::size_t size, std::size_t max_size, unsigned int seed) {
+    return ProtoFuzzerCustomMutator(Profile, data, size, max_size, seed);
+  }
+
+  /// Forward crossover through the fixed profile so children are normalized
+  /// for the same lane as both ordinary mutations and execution.
+  /// @param data1 First serialized parent.
+  /// @param size1 Size of data1.
+  /// @param data2 Second serialized parent.
+  /// @param size2 Size of data2.
+  /// @param out Destination storage.
+  /// @param max_out_size Capacity of out.
+  /// @param seed Crossover random seed supplied by libFuzzer.
+  /// @return Serialized child size.
+  static std::size_t CustomCrossOver(const std::uint8_t* data1, std::size_t size1, const std::uint8_t* data2,
+                                     std::size_t size2, std::uint8_t* out, std::size_t max_out_size,
+                                     unsigned int seed) {
+    return ProtoFuzzerCustomCrossOver(Profile, data1, size1, data2, size2, out, max_out_size, seed);
+  }
+};
 
 }  // namespace proto_fuzzer
 

--- a/proto_fuzzer/mock_server.cc
+++ b/proto_fuzzer/mock_server.cc
@@ -290,9 +290,15 @@ void MockServer::ObserveActiveTransfer(CURL* /*easy*/) {}
 /// Called by the OPENSOCKETFUNCTION trampoline in the base class. Creates the
 /// MockConnection, writes initial_response into it, and returns the
 /// client-side fd to hand to libcurl.
+/// @param purpose Socket role requested by curl; ordinary stream mocks do not
+///                need to distinguish outbound HTTP roles.
+/// @param address Intended destination retained by curl; the socketpair is
+///                already connected and therefore leaves it untouched.
 /// @return the client-side fd to hand to libcurl, or CURL_SOCKET_BAD on
 ///         failure.
-curl_socket_t MockServer::HandleOpenSocket() {
+curl_socket_t MockServer::HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) {
+  (void)purpose;
+  (void)address;
   if (next_script_ >= script_count_) {
     // Refusing a fifth socket keeps redirect loops bounded even if curl's own
     // redirect limit is mutated upward or an authentication scheme retries.

--- a/proto_fuzzer/mock_server.h
+++ b/proto_fuzzer/mock_server.h
@@ -119,7 +119,8 @@ class MockServer : public MockServerBase {
   /// multi handle has been dismantled.
   virtual void ObserveActiveTransfer(CURL* easy);
 
-  curl_socket_t HandleOpenSocket() override;
+  curl_socket_t HandleOpenSocket(curlsocktype purpose = CURLSOCKTYPE_IPCXN,
+                                 struct curl_sockaddr* address = nullptr) override;
   void RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) override;
 
  private:

--- a/proto_fuzzer/mock_server_base.cc
+++ b/proto_fuzzer/mock_server_base.cc
@@ -12,6 +12,7 @@
 #include "proto_fuzzer/mock_server_base.h"
 
 #include <sys/select.h>
+#include <sys/socket.h>
 
 #include "proto_fuzzer/mock_server.h"
 #include "proto_fuzzer/multi_socket_driver.h"
@@ -22,10 +23,23 @@ namespace {
 
 constexpr long kSelectTimeoutUs = 1000;  // 1 ms; explicit timing cases only.
 
-/// @brief Noop function to satisfy CURLOPT_SOCKOPTFUNCTION.
-/// @return CURL_SOCKOPT_ALREADY_CONNECTED: the socketpair is already connected.
-int SockOptTrampoline(void* /*clientp*/, curl_socket_t /*curlfd*/, curlsocktype /*purpose*/) {
-  return CURL_SOCKOPT_ALREADY_CONNECTED;
+/// Tell curl whether the peer supplied an already-connected socketpair or a
+/// real datagram socket that still needs protocol-owned setup. Returning the
+/// socketpair answer unconditionally made the old TFTP harness skip the wrong
+/// setup assumptions and eventually call IP operations on an AF_UNIX stream.
+/// Accepted sockets are already established by curl itself, where the callback
+/// contract treats any non-zero result as an error rather than as a shortcut.
+int SockOptTrampoline(void* /*clientp*/, curl_socket_t curlfd, curlsocktype purpose) {
+  if (purpose == CURLSOCKTYPE_ACCEPT) {
+    return CURL_SOCKOPT_OK;
+  }
+
+  int socket_type = 0;
+  socklen_t socket_type_size = sizeof(socket_type);
+  if (getsockopt(curlfd, SOL_SOCKET, SO_TYPE, &socket_type, &socket_type_size) != 0) {
+    return CURL_SOCKOPT_ERROR;
+  }
+  return socket_type == SOCK_DGRAM ? CURL_SOCKOPT_OK : CURL_SOCKOPT_ALREADY_CONNECTED;
 }
 
 }  // namespace
@@ -33,10 +47,11 @@ int SockOptTrampoline(void* /*clientp*/, curl_socket_t /*curlfd*/, curlsocktype 
 /// @brief C trampoline for CURLOPT_OPENSOCKETFUNCTION. Declared at namespace
 ///        scope so it can be a friend of MockServerBase.
 /// @param clientp Pointer to the MockServerBase instance.
+/// @param purpose The socket role curl is asking the mock to provide.
+/// @param address Curl's mutable description of the intended destination.
 /// @return The client-side socket fd as a curl_socket_t.
-curl_socket_t MockServerBaseOpenSocketTrampoline(void* clientp, curlsocktype /*purpose*/,
-                                                 struct curl_sockaddr* /*address*/) {
-  return static_cast<MockServerBase*>(clientp)->HandleOpenSocket();
+curl_socket_t MockServerBaseOpenSocketTrampoline(void* clientp, curlsocktype purpose, struct curl_sockaddr* address) {
+  return static_cast<MockServerBase*>(clientp)->HandleOpenSocket(purpose, address);
 }
 
 /// Default-construct an empty base instance with no connection.

--- a/proto_fuzzer/mock_server_base.h
+++ b/proto_fuzzer/mock_server_base.h
@@ -86,9 +86,14 @@ class MockServerBase {
 
   /// Subclass hook invoked by the OPENSOCKET trampoline. The subclass owns the
   /// decision to construct `connection_`, push any initial bytes, and hand the
-  /// client fd back to libcurl.
+  /// client fd back to libcurl. Passing curl's mutable destination through is
+  /// essential for datagram protocols: TFTP must replace the nominal URL port
+  /// with its per-scenario loopback request socket before curl records the
+  /// address used by sendto(). Stream socketpair peers simply ignore it.
+  /// @param purpose The role curl intends the new socket to serve.
+  /// @param address Mutable destination and native socket description.
   /// @return the client-side fd to hand to libcurl, or CURL_SOCKET_BAD.
-  virtual curl_socket_t HandleOpenSocket() = 0;
+  virtual curl_socket_t HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) = 0;
 
   /// Subclass hook invoked from DriveScenario. Runs the protocol-specific
   /// perform loop against a caller-owned multi that already has 'easy' added.

--- a/proto_fuzzer/option_apply.cc
+++ b/proto_fuzzer/option_apply.cc
@@ -48,6 +48,8 @@ namespace {
 
 constexpr char kEventDrivenProtocolsAllowed[] = "http,https,ws,wss";
 constexpr char kTelnetProtocolAllowed[] = "telnet";
+constexpr char kFtpProtocolAllowed[] = "ftp";
+constexpr char kTftpProtocolAllowed[] = "tftp";
 constexpr char kConnectToOverride[] = "::127.0.1.127:";
 constexpr char kDevNull[] = "/dev/null";
 constexpr char kVerboseEnvVar[] = "FUZZ_VERBOSE";
@@ -204,12 +206,29 @@ struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme 
     curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
   }
 
-  // A TELNET transfer must use TelnetMockServer's preload/drain invariants.
-  // Keep it out of the redirect allowlist so an HTTP mock can never redirect
-  // into curl's synchronous TELNET driver with event-driven peer semantics.
+  // Each non-HTTP protocol must use its dedicated peer invariants. Keep them
+  // out of the redirect allowlist so an HTTP response cannot switch a stream
+  // mock into synchronous TELNET, two-channel FTP, or datagram TFTP semantics.
   // CURLOPT_PROTOCOLS_STR arrived in 7.85.0.
-  const char* direct_protocols =
-      scheme == curl::fuzzer::proto::SCHEME_TELNET ? kTelnetProtocolAllowed : kEventDrivenProtocolsAllowed;
+  const char* direct_protocols = kEventDrivenProtocolsAllowed;
+  switch (scheme) {
+    case curl::fuzzer::proto::SCHEME_TELNET:
+      direct_protocols = kTelnetProtocolAllowed;
+      break;
+    case curl::fuzzer::proto::SCHEME_FTP:
+      direct_protocols = kFtpProtocolAllowed;
+      break;
+    case curl::fuzzer::proto::SCHEME_TFTP:
+      direct_protocols = kTftpProtocolAllowed;
+      break;
+    case curl::fuzzer::proto::SCHEME_HTTP:
+    case curl::fuzzer::proto::SCHEME_HTTPS:
+    case curl::fuzzer::proto::SCHEME_WS:
+    case curl::fuzzer::proto::SCHEME_WSS:
+    case curl::fuzzer::proto::SCHEME_UNSPECIFIED:
+    default:
+      break;
+  }
   curl_easy_setopt(easy, CURLOPT_PROTOCOLS_STR, direct_protocols);
   curl_easy_setopt(easy, CURLOPT_REDIR_PROTOCOLS_STR, kEventDrivenProtocolsAllowed);
 

--- a/proto_fuzzer/scenario_runner.cc
+++ b/proto_fuzzer/scenario_runner.cc
@@ -17,11 +17,13 @@
 #include <string>
 
 #include "proto_fuzzer/api_lifecycle.h"
+#include "proto_fuzzer/ftp_mock_server.h"
 #include "proto_fuzzer/mock_server.h"
 #include "proto_fuzzer/mock_server_base.h"
 #include "proto_fuzzer/option_apply.h"
 #include "proto_fuzzer/request_data.h"
 #include "proto_fuzzer/telnet_mock_server.h"
+#include "proto_fuzzer/tftp_mock_server.h"
 #include "proto_fuzzer/websocket_mock_server.h"
 
 #if defined(PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
@@ -96,6 +98,10 @@ const char* SchemePrefix(curl::fuzzer::proto::Scheme scheme) {
       return "wss";
     case curl::fuzzer::proto::SCHEME_TELNET:
       return "telnet";
+    case curl::fuzzer::proto::SCHEME_FTP:
+      return "ftp";
+    case curl::fuzzer::proto::SCHEME_TFTP:
+      return "tftp";
     case curl::fuzzer::proto::SCHEME_UNSPECIFIED:
     default:
       return nullptr;
@@ -126,6 +132,22 @@ std::unique_ptr<MockServerBase> MakeMockServerForScenario(const curl::fuzzer::pr
       return std::make_unique<WebSocketMockServer>();
     case curl::fuzzer::proto::SCHEME_TELNET:
       return std::make_unique<TelnetMockServer>();
+    case curl::fuzzer::proto::SCHEME_FTP:
+      // New numeric enum values may already occur in the historical mixed
+      // corpus as unknown fields. Only the fixed FTP profile may reinterpret
+      // one as a live two-channel protocol exchange.
+      if (mode == ScenarioRunMode::kFtpCoverage) {
+        return std::make_unique<FtpMockServer>();
+      }
+      return nullptr;
+    case curl::fuzzer::proto::SCHEME_TFTP:
+      // TFTP changes the callback transport from a preconnected stream to a
+      // real UDP endpoint, so compatibility inputs must not opt into it merely
+      // because this build learned a new enum value.
+      if (mode == ScenarioRunMode::kTftpCoverage) {
+        return std::make_unique<TftpMockServer>();
+      }
+      return nullptr;
     case curl::fuzzer::proto::SCHEME_UNSPECIFIED:
     default:
       return nullptr;

--- a/proto_fuzzer/target_policy.cc
+++ b/proto_fuzzer/target_policy.cc
@@ -66,6 +66,36 @@ void CanonicalizeTlsAuthority(curl::fuzzer::proto::Scenario* scenario) {
   scenario->set_host_path("tls.test" + host_path.substr(suffix_start));
 }
 
+/// Give the TFTP lane a parseable filename-bearing URL while retaining the
+/// fuzz-controlled path, query, and fragment. The UDP peer rewrites curl's
+/// destination after URL parsing, so authority mutations cannot reach another
+/// host; canonicalizing them here avoids spending most iterations on failures
+/// before curl constructs a TFTP request. An explicit slash is preserved so
+/// the missing-filename error remains reachable.
+void CanonicalizeTftpAuthority(curl::fuzzer::proto::Scenario* scenario) {
+  const std::string& host_path = scenario->host_path();
+  const std::size_t suffix_start = host_path.find_first_of("/?#");
+  if (suffix_start == std::string::npos) {
+    scenario->set_host_path("tftp.test/file");
+    return;
+  }
+  scenario->set_host_path("tftp.test" + host_path.substr(suffix_start));
+}
+
+/// Keep the FTP lane inside the same parseable authority while leaving every
+/// path segment and wildcard under mutation control. CONNECT_TO already
+/// confines networking, but rejecting malformed authorities before USER/PWD
+/// would waste the control/data peer this target uniquely provides.
+void CanonicalizeFtpAuthority(curl::fuzzer::proto::Scenario* scenario) {
+  const std::string& host_path = scenario->host_path();
+  const std::size_t suffix_start = host_path.find_first_of("/?#");
+  if (suffix_start == std::string::npos) {
+    scenario->set_host_path("ftp.test/file");
+    return;
+  }
+  scenario->set_host_path("ftp.test" + host_path.substr(suffix_start));
+}
+
 template <typename RepeatedBytes>
 void BoundStringValues(RepeatedBytes* values, std::size_t count_limit, std::size_t value_limit) {
   TrimRepeated(values, count_limit);
@@ -264,15 +294,16 @@ bool IsCheapHttpOption(curl::fuzzer::proto::CurlOptionId option_id) {
   }
 }
 
-/// Compact the option list before applying the general option-count bound.
-/// Keeping an allowed option that appears after a long rejected prefix is
-/// important for mutation density: bounding first would let expensive options
-/// crowd cheap ones out of the only lane intended to approach legacy speed.
-void RetainCheapHttpOptions(curl::fuzzer::proto::Scenario* scenario) {
+/// Compact an option list before applying the general option-count bound.
+/// Keeping a relevant option that appears after a long rejected prefix is
+/// important for mutation density: bounding first would let unrelated options
+/// crowd useful ones out of a protocol-specific lane.
+template <typename Predicate>
+void RetainMatchingOptions(curl::fuzzer::proto::Scenario* scenario, Predicate predicate) {
   auto* options = scenario->mutable_options();
   int retained = 0;
   for (int index = 0; index < options->size(); ++index) {
-    if (!IsCheapHttpOption(options->Get(index).option_id())) {
+    if (!predicate(options->Get(index).option_id())) {
       continue;
     }
     if (retained != index) {
@@ -281,6 +312,12 @@ void RetainCheapHttpOptions(curl::fuzzer::proto::Scenario* scenario) {
     ++retained;
   }
   options->DeleteSubrange(retained, options->size() - retained);
+}
+
+/// Keep the high-throughput HTTP lane free of options whose setup or state is
+/// assigned to a deeper or protocol-specific target.
+void RetainCheapHttpOptions(curl::fuzzer::proto::Scenario* scenario) {
+  RetainMatchingOptions(scenario, &IsCheapHttpOption);
 }
 
 /// Return whether a scalar option can influence TELNET without selecting an
@@ -305,18 +342,161 @@ bool IsCheapTelnetOption(curl::fuzzer::proto::CurlOptionId option_id) {
 /// useful credentials, CRLF handling, and transfer-size controls out of the
 /// fixed target's general option budget.
 void RetainCheapTelnetOptions(curl::fuzzer::proto::Scenario* scenario) {
-  auto* options = scenario->mutable_options();
-  int retained = 0;
-  for (int index = 0; index < options->size(); ++index) {
-    if (!IsCheapTelnetOption(options->Get(index).option_id())) {
+  RetainMatchingOptions(scenario, &IsCheapTelnetOption);
+}
+
+/// Return whether an option can change a plaintext FTP transfer serviced by
+/// the bounded control/data peer. Active mode and FTPS settings are omitted:
+/// retaining them would select socket and TLS behavior this target does not
+/// provide, turning otherwise-useful mutations into early setup failures.
+bool IsFtpOption(curl::fuzzer::proto::CurlOptionId option_id) {
+  switch (option_id) {
+    case curl::fuzzer::proto::CURLOPT_APPEND:
+    case curl::fuzzer::proto::CURLOPT_BUFFERSIZE:
+    case curl::fuzzer::proto::CURLOPT_CRLF:
+    case curl::fuzzer::proto::CURLOPT_CUSTOMREQUEST:
+    case curl::fuzzer::proto::CURLOPT_DIRLISTONLY:
+    case curl::fuzzer::proto::CURLOPT_FILETIME:
+    case curl::fuzzer::proto::CURLOPT_FTP_ACCOUNT:
+    case curl::fuzzer::proto::CURLOPT_FTP_ALTERNATIVE_TO_USER:
+    case curl::fuzzer::proto::CURLOPT_FTP_CREATE_MISSING_DIRS:
+    case curl::fuzzer::proto::CURLOPT_FTP_FILEMETHOD:
+    case curl::fuzzer::proto::CURLOPT_FTP_SKIP_PASV_IP:
+    case curl::fuzzer::proto::CURLOPT_FTP_USE_EPSV:
+    case curl::fuzzer::proto::CURLOPT_FTP_USE_PRET:
+    case curl::fuzzer::proto::CURLOPT_INFILESIZE_LARGE:
+    case curl::fuzzer::proto::CURLOPT_MAXFILESIZE_LARGE:
+    case curl::fuzzer::proto::CURLOPT_NOBODY:
+    case curl::fuzzer::proto::CURLOPT_PASSWORD:
+    case curl::fuzzer::proto::CURLOPT_RANGE:
+    case curl::fuzzer::proto::CURLOPT_RESUME_FROM_LARGE:
+    case curl::fuzzer::proto::CURLOPT_TIMECONDITION:
+    case curl::fuzzer::proto::CURLOPT_TIMEVALUE_LARGE:
+    case curl::fuzzer::proto::CURLOPT_TRANSFERTEXT:
+    case curl::fuzzer::proto::CURLOPT_UPLOAD:
+    case curl::fuzzer::proto::CURLOPT_UPLOAD_BUFFERSIZE:
+    case curl::fuzzer::proto::CURLOPT_USERNAME:
+    case curl::fuzzer::proto::CURLOPT_USERPWD:
+    case curl::fuzzer::proto::CURLOPT_WILDCARDMATCH:
+      return true;
+
+    case curl::fuzzer::proto::CURL_OPTION_UNSPECIFIED:
+    default:
+      return false;
+  }
+}
+
+/// Keep the FTP target's general option budget focused on states its passive
+/// peer can actually advance.
+void RetainFtpOptions(curl::fuzzer::proto::Scenario* scenario) { RetainMatchingOptions(scenario, &IsFtpOption); }
+
+/// Return whether an option affects TFTP request construction, option
+/// negotiation, transfer direction, or bounded body delivery. TFTP has no
+/// connection reuse or stream-level controls, so retaining those settings
+/// would add protobuf work without another state-machine edge in curl.
+bool IsTftpOption(curl::fuzzer::proto::CurlOptionId option_id) {
+  switch (option_id) {
+    case curl::fuzzer::proto::CURLOPT_CRLF:
+    case curl::fuzzer::proto::CURLOPT_INFILESIZE_LARGE:
+    case curl::fuzzer::proto::CURLOPT_MAXFILESIZE_LARGE:
+    case curl::fuzzer::proto::CURLOPT_NOBODY:
+    case curl::fuzzer::proto::CURLOPT_TFTP_BLKSIZE:
+    case curl::fuzzer::proto::CURLOPT_TFTP_NO_OPTIONS:
+    case curl::fuzzer::proto::CURLOPT_TRANSFERTEXT:
+    case curl::fuzzer::proto::CURLOPT_UPLOAD:
+      return true;
+
+    case curl::fuzzer::proto::CURL_OPTION_UNSPECIFIED:
+    default:
+      return false;
+  }
+}
+
+/// Keep the datagram lane from spending mutations on stream-only options.
+void RetainTftpOptions(curl::fuzzer::proto::Scenario* scenario) { RetainMatchingOptions(scenario, &IsTftpOption); }
+
+/// Decode an integral oneof locally before the generated option canonicalizer
+/// runs. Protocol mode bounds are policy, not setopt mechanics: folding them
+/// here keeps nearly every mutation on a real FTP/TFTP state while the shared
+/// option layer remains unaware of protocol-specific numeric ranges.
+std::uint64_t IntegralMutationValue(const curl::fuzzer::proto::SetOption& option) {
+  switch (option.value_case()) {
+    case curl::fuzzer::proto::SetOption::kUintValue:
+      return option.uint_value();
+    case curl::fuzzer::proto::SetOption::kBoolValue:
+      return option.bool_value() ? 1U : 0U;
+    case curl::fuzzer::proto::SetOption::kStringValue:
+    case curl::fuzzer::proto::SetOption::VALUE_NOT_SET:
+      return 0;
+  }
+  return 0;
+}
+
+/// Fold small FTP enums onto curl's documented domains so random uint64 values
+/// do not overwhelmingly stop at setopt validation before issuing a command.
+void CanonicalizeFtpOptionModes(curl::fuzzer::proto::Scenario* scenario) {
+  for (auto& option : *scenario->mutable_options()) {
+    switch (option.option_id()) {
+      case curl::fuzzer::proto::CURLOPT_FTP_CREATE_MISSING_DIRS:
+        option.set_uint_value(IntegralMutationValue(option) % 3U);
+        break;
+      case curl::fuzzer::proto::CURLOPT_FTP_FILEMETHOD:
+        option.set_uint_value(IntegralMutationValue(option) % 4U);
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+/// TFTP accepts block sizes from 8 through 65464. Mapping zero or a mismatched
+/// oneof to the default 512 preserves a common valid request, while saturating
+/// other values retains both lower/upper parser boundaries under mutation.
+void CanonicalizeTftpOptionModes(curl::fuzzer::proto::Scenario* scenario) {
+  for (auto& option : *scenario->mutable_options()) {
+    if (option.option_id() != curl::fuzzer::proto::CURLOPT_TFTP_BLKSIZE) {
       continue;
     }
-    if (retained != index) {
-      options->SwapElements(retained, index);
+    std::uint64_t value = IntegralMutationValue(option);
+    if (value == 0) {
+      value = 512;
     }
-    ++retained;
+    option.set_uint_value(std::max<std::uint64_t>(8, std::min<std::uint64_t>(value, 65464)));
   }
-  options->DeleteSubrange(retained, options->size() - retained);
+}
+
+/// Identify options introduced for FTP/TFTP so existing fixed lanes do not
+/// silently inherit dead mutations when the shared generated manifest grows.
+/// Generic options retained by the FTP/TFTP allowlists are deliberately absent
+/// here because they remain useful to HTTP, WebSocket, API, or timing targets.
+bool IsFileTransferOnlyOption(curl::fuzzer::proto::CurlOptionId option_id) {
+  switch (option_id) {
+    case curl::fuzzer::proto::CURLOPT_APPEND:
+    case curl::fuzzer::proto::CURLOPT_DIRLISTONLY:
+    case curl::fuzzer::proto::CURLOPT_FTP_ACCOUNT:
+    case curl::fuzzer::proto::CURLOPT_FTP_ALTERNATIVE_TO_USER:
+    case curl::fuzzer::proto::CURLOPT_FTP_CREATE_MISSING_DIRS:
+    case curl::fuzzer::proto::CURLOPT_FTP_FILEMETHOD:
+    case curl::fuzzer::proto::CURLOPT_FTP_SKIP_PASV_IP:
+    case curl::fuzzer::proto::CURLOPT_FTP_USE_EPSV:
+    case curl::fuzzer::proto::CURLOPT_FTP_USE_PRET:
+    case curl::fuzzer::proto::CURLOPT_TFTP_BLKSIZE:
+    case curl::fuzzer::proto::CURLOPT_TFTP_NO_OPTIONS:
+    case curl::fuzzer::proto::CURLOPT_TRANSFERTEXT:
+    case curl::fuzzer::proto::CURLOPT_WILDCARDMATCH:
+      return true;
+
+    case curl::fuzzer::proto::CURL_OPTION_UNSPECIFIED:
+    default:
+      return false;
+  }
+}
+
+/// Remove FTP/TFTP-only options while preserving the relative order of every
+/// generic option an existing fixed target already consumed.
+void RemoveFileTransferOnlyOptions(curl::fuzzer::proto::Scenario* scenario) {
+  RetainMatchingOptions(
+      scenario, [](curl::fuzzer::proto::CurlOptionId option_id) { return !IsFileTransferOnlyOption(option_id); });
 }
 
 /// Remove the stateful shapes assigned to the deep HTTP target. This happens
@@ -376,6 +556,45 @@ void RemoveTelnetOnlyShape(curl::fuzzer::proto::Scenario* scenario) {
 /// existing reproducers keep their historical serialized meaning.
 void RemoveApiOnlyShape(curl::fuzzer::proto::Scenario* scenario) { scenario->clear_api_plan(); }
 
+/// Remove stream-driver controls that neither file-transfer peer interprets.
+/// FTP consumes raw byte chunks as control/data replies, while TFTP preserves
+/// them as individual datagrams; structured WebSocket frames, manual probes,
+/// and event-loop backpressure therefore cannot affect either curl protocol.
+void RemoveUnusedFileTransferConnectionShape(curl::fuzzer::proto::Connection* connection) {
+  connection->clear_server_frames();
+  connection->clear_manual_probes();
+  connection->clear_backpressure();
+}
+
+/// Retain only the reusable shapes consumed by the FTP peer: one raw control
+/// script, a bounded sequence of passive-data scripts, and optional upload
+/// input. HTTP, TELNET, WebSocket, and public-API fields would otherwise absorb
+/// mutations despite having no representation in an FTP exchange.
+void RemoveIgnoredFtpShape(curl::fuzzer::proto::Scenario* scenario) {
+  scenario->clear_request_headers();
+  scenario->clear_mime_post();
+  RemoveTelnetOnlyShape(scenario);
+  RemoveApiOnlyShape(scenario);
+
+  RemoveUnusedFileTransferConnectionShape(scenario->mutable_connection());
+  TrimRepeated(scenario->mutable_subsequent_connections(), scenario_limits::kMaxConnections - 1);
+  for (auto& connection : *scenario->mutable_subsequent_connections()) {
+    RemoveUnusedFileTransferConnectionShape(&connection);
+  }
+}
+
+/// Retain the primary raw response script because its entries are the ordered
+/// UDP datagrams seen by curl, plus optional upload input for WRQ. TFTP cannot
+/// consume follow-on stream connections or any higher-level protocol shape.
+void RemoveIgnoredTftpShape(curl::fuzzer::proto::Scenario* scenario) {
+  scenario->clear_subsequent_connections();
+  scenario->clear_request_headers();
+  scenario->clear_mime_post();
+  RemoveTelnetOnlyShape(scenario);
+  RemoveApiOnlyShape(scenario);
+  RemoveUnusedFileTransferConnectionShape(scenario->mutable_connection());
+}
+
 /// Preserve useful in-range mutations while folding ineffective extremes onto
 /// meaningful boundaries. Zero remains special: it disables that individual
 /// control and lets the other control provide the timing target's pressure.
@@ -397,6 +616,8 @@ curl::fuzzer::proto::Scheme PlaintextScheme(curl::fuzzer::proto::Scheme scheme) 
     case curl::fuzzer::proto::SCHEME_HTTP:
     case curl::fuzzer::proto::SCHEME_HTTPS:
     case curl::fuzzer::proto::SCHEME_TELNET:
+    case curl::fuzzer::proto::SCHEME_FTP:
+    case curl::fuzzer::proto::SCHEME_TFTP:
     case curl::fuzzer::proto::SCHEME_UNSPECIFIED:
     default:
       return curl::fuzzer::proto::SCHEME_HTTP;
@@ -447,7 +668,8 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
   if (profile == TargetProfile::kCompatibility) {
     // The original target's existing corpus predates profile splitting. A
     // no-op here makes the type safe to pass around while its binary continues
-    // to omit postprocessor registration altogether.
+    // to omit postprocessor registration altogether. The append-only FTP/TFTP
+    // scheme values do not justify rewriting historical mixed-lane inputs.
     return;
   }
 
@@ -470,6 +692,26 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     RemoveDeepHttpShape(scenario);
     RetainCheapHttpOptions(scenario);
     BoundScenarioShape(scenario);
+    return;
+  }
+
+  if (profile == TargetProfile::kFastFtp) {
+    scenario->set_scheme(curl::fuzzer::proto::SCHEME_FTP);
+    RemoveIgnoredFtpShape(scenario);
+    RetainFtpOptions(scenario);
+    CanonicalizeFtpOptionModes(scenario);
+    BoundScenarioShape(scenario);
+    CanonicalizeFtpAuthority(scenario);
+    return;
+  }
+
+  if (profile == TargetProfile::kFastTftp) {
+    scenario->set_scheme(curl::fuzzer::proto::SCHEME_TFTP);
+    RemoveIgnoredTftpShape(scenario);
+    RetainTftpOptions(scenario);
+    CanonicalizeTftpOptionModes(scenario);
+    BoundScenarioShape(scenario);
+    CanonicalizeTftpAuthority(scenario);
     return;
   }
 
@@ -500,7 +742,9 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
       break;
     case TargetProfile::kFastHttp:
     case TargetProfile::kFastTelnet:
-      // Both early-return paths selected their scheme above.
+    case TargetProfile::kFastFtp:
+    case TargetProfile::kFastTftp:
+      // Protocol-specific early-return paths selected their scheme above.
       return;
   }
 
@@ -512,6 +756,7 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
   if (profile != TargetProfile::kApi) {
     RemoveApiOnlyShape(scenario);
   }
+  RemoveFileTransferOnlyOptions(scenario);
   BoundScenarioShape(scenario);
 
   switch (profile) {
@@ -554,6 +799,12 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     case TargetProfile::kFastTelnet:
       // Handled before the general bounds so its protocol-specific limits are
       // selected from the start.
+      return;
+
+    case TargetProfile::kFastFtp:
+    case TargetProfile::kFastTftp:
+      // Their peers consume narrower raw-script shapes, pruned before general
+      // bounds so ignored fields never tax these fast paths.
       return;
 
     case TargetProfile::kTiming: {

--- a/proto_fuzzer/target_profile.h
+++ b/proto_fuzzer/target_profile.h
@@ -30,6 +30,10 @@ enum class TargetProfile {
   kFastSecureWebSocket,
   /// Exercise bounded TELNET negotiation and callback-backed input.
   kFastTelnet,
+  /// Exercise FTP control and passive data connections without external I/O.
+  kFastFtp,
+  /// Exercise packet-preserving TFTP exchanges over the loopback UDP peer.
+  kFastTftp,
   /// Exercise easy, share, multi, URL, and result API lifecycles.
   kApi,
   /// Isolate deterministic backpressure and timed-wait behavior.
@@ -45,6 +49,10 @@ enum class ScenarioRunMode {
   kProtocolCoverage,
   /// Drive HTTPS through a real TLS peer and inspect live TLS result state.
   kTlsCoverage,
+  /// Drive FTP through its concurrent control/passive-data peer.
+  kFtpCoverage,
+  /// Drive TFTP through its datagram-preserving loopback peer.
+  kTftpCoverage,
   /// Honour ApiPlan and run the dedicated lifecycle and typed-result probes.
   kApiLifecycle,
 };
@@ -65,6 +73,12 @@ constexpr ScenarioRunMode RunModeFor(TargetProfile profile) {
 
     case TargetProfile::kFastHttps:
       return ScenarioRunMode::kTlsCoverage;
+
+    case TargetProfile::kFastFtp:
+      return ScenarioRunMode::kFtpCoverage;
+
+    case TargetProfile::kFastTftp:
+      return ScenarioRunMode::kTftpCoverage;
 
     case TargetProfile::kCompatibility:
     case TargetProfile::kDeepHttp:

--- a/proto_fuzzer/telnet_mock_server.cc
+++ b/proto_fuzzer/telnet_mock_server.cc
@@ -97,8 +97,14 @@ void TelnetMockServer::DrainBeforeUploadRead(void* userdata) {
 /// non-blocking server fd; if a compatibility input exceeds the socket buffer,
 /// the retained prefix is still useful and the half-close still guarantees
 /// termination.
+/// @param purpose Socket role requested by curl; TELNET uses one outbound
+///                stream and does not need role-specific setup.
+/// @param address Intended destination retained by curl; the already-connected
+///                socketpair does not need to rewrite it.
 /// @return The preloaded client socket, or CURL_SOCKET_BAD on setup failure.
-curl_socket_t TelnetMockServer::HandleOpenSocket() {
+curl_socket_t TelnetMockServer::HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) {
+  (void)purpose;
+  (void)address;
   if (scenario_ == nullptr || socket_opened_) {
     return CURL_SOCKET_BAD;
   }

--- a/proto_fuzzer/telnet_mock_server.h
+++ b/proto_fuzzer/telnet_mock_server.h
@@ -40,7 +40,8 @@ class TelnetMockServer final : public MockServerBase {
   void ConfigureRequestData(ScenarioRequestData* request_data) override;
 
  protected:
-  curl_socket_t HandleOpenSocket() override;
+  curl_socket_t HandleOpenSocket(curlsocktype purpose = CURLSOCKTYPE_IPCXN,
+                                 struct curl_sockaddr* address = nullptr) override;
   void RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) override;
 
  private:

--- a/proto_fuzzer/tftp_mock_server.cc
+++ b/proto_fuzzer/tftp_mock_server.cc
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+/// @file
+/// @brief Implementation of the bounded loopback UDP TFTP peer.
+
+#include "proto_fuzzer/tftp_mock_server.h"
+
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <utility>
+
+namespace proto_fuzzer {
+
+/// Start without live descriptors or borrowed scenario storage. RunLoop builds
+/// both immediately before the first curl_multi_perform that can observe them.
+TftpMockServer::TftpMockServer()
+    : response_datagrams_(),
+      response_datagram_count_(0),
+      next_response_datagram_(0),
+      request_fd_(-1),
+      transfer_fd_(-1),
+      client_address_(),
+      client_address_length_(0),
+      has_client_address_(false),
+      socket_opened_(false),
+      request_port_(0),
+      transfer_port_(0),
+      received_datagrams_() {}
+
+/// Close the two server endpoints after the base drive has removed curl's
+/// separately-owned client descriptor from its multi handle.
+TftpMockServer::~TftpMockServer() { ResetPeer(); }
+
+/// Return observations rather than parsing them in the peer. Tests can assert
+/// exact RRQ/WRQ/DATA/ACK bytes while production fuzz iterations pay only the
+/// bounded copies already required to expose those observations.
+const std::vector<TftpReceivedDatagram>& TftpMockServer::received_datagrams() const { return received_datagrams_; }
+
+/// Return the kernel-selected request port in host byte order.
+std::uint16_t TftpMockServer::request_port() const { return request_port_; }
+
+/// Return the kernel-selected transfer port in host byte order.
+std::uint16_t TftpMockServer::transfer_port() const { return transfer_port_; }
+
+/// Borrow only the response prefix the runtime can emit. The nonempty check on
+/// initial_response preserves proto3's absent/empty equivalence; repeated bytes
+/// retain presence, so an empty on_readable entry remains a real zero-length
+/// UDP datagram useful for curl's short-packet retry path.
+void TftpMockServer::PrepareScript(const curl::fuzzer::proto::Connection& connection) {
+  response_datagrams_.fill(nullptr);
+  response_datagram_count_ = 0;
+  next_response_datagram_ = 0;
+
+  if (!connection.initial_response().empty()) {
+    response_datagrams_[response_datagram_count_++] = &connection.initial_response();
+  }
+  const std::size_t chunk_count =
+      std::min<std::size_t>(scenario_limits::kMaxResponseChunks, connection.on_readable_size());
+  for (std::size_t index = 0; index < chunk_count; ++index) {
+    response_datagrams_[response_datagram_count_++] = &connection.on_readable(static_cast<int>(index));
+  }
+}
+
+/// Tear down only state owned by this mock. Curl takes ownership of the client
+/// descriptor as soon as HandleOpenSocket succeeds, so retaining or closing a
+/// duplicate here would create cross-owner lifetime bugs during multi cleanup.
+void TftpMockServer::ResetPeer() {
+  if (request_fd_ >= 0) {
+    (void)::close(request_fd_);
+    request_fd_ = -1;
+  }
+  if (transfer_fd_ >= 0) {
+    (void)::close(transfer_fd_);
+    transfer_fd_ = -1;
+  }
+  std::memset(&client_address_, 0, sizeof(client_address_));
+  client_address_length_ = 0;
+  has_client_address_ = false;
+  socket_opened_ = false;
+  request_port_ = 0;
+  transfer_port_ = 0;
+}
+
+/// Establish both descriptor properties ourselves. Curl normally requests
+/// SOCK_CLOEXEC/SOCK_NONBLOCK from socket(), but an application callback is
+/// allowed to ignore those type flags and therefore must return a safe fd.
+bool TftpMockServer::ConfigureSocket(int fd) {
+  if (fd < 0) {
+    return false;
+  }
+  const int descriptor_flags = ::fcntl(fd, F_GETFD, 0);
+  if (descriptor_flags < 0 || ::fcntl(fd, F_SETFD, descriptor_flags | FD_CLOEXEC) < 0) {
+    return false;
+  }
+  const int status_flags = ::fcntl(fd, F_GETFL, 0);
+  return status_flags >= 0 && ::fcntl(fd, F_SETFL, status_flags | O_NONBLOCK) == 0;
+}
+
+/// Use ephemeral loopback ports so parallel fuzz workers cannot collide and no
+/// privilege is required for TFTP's conventional port 69. getsockname, rather
+/// than assumptions about bind(), is the authority on the chosen destination.
+int TftpMockServer::OpenLoopbackSocket(struct sockaddr_in* bound_address) {
+  if (bound_address == nullptr) {
+    return -1;
+  }
+  const int fd = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (fd < 0 || !ConfigureSocket(fd)) {
+    if (fd >= 0) {
+      (void)::close(fd);
+    }
+    return -1;
+  }
+
+  struct sockaddr_in requested = {};
+  requested.sin_family = AF_INET;
+  requested.sin_port = htons(0);
+  requested.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  if (::bind(fd, reinterpret_cast<const struct sockaddr*>(&requested), sizeof(requested)) != 0) {
+    (void)::close(fd);
+    return -1;
+  }
+
+  socklen_t length = sizeof(*bound_address);
+  std::memset(bound_address, 0, sizeof(*bound_address));
+  if (::getsockname(fd, reinterpret_cast<struct sockaddr*>(bound_address), &length) != 0 ||
+      length != sizeof(*bound_address) || bound_address->sin_family != AF_INET) {
+    (void)::close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+/// Curl explicitly permits CURLOPT_OPENSOCKETFUNCTION to replace its supplied
+/// destination. Replacing the metadata as well as sockaddr is essential: curl
+/// copies these values into its connection filter and TFTP later retrieves that
+/// copy for sendto(), independently of the returned descriptor's properties.
+bool TftpMockServer::RewriteDestination(struct curl_sockaddr* address, const struct sockaddr_in& destination) {
+  if (address == nullptr || sizeof(destination) > sizeof(address->addr)) {
+    return false;
+  }
+  address->family = AF_INET;
+  address->socktype = SOCK_DGRAM;
+  address->protocol = IPPROTO_UDP;
+  address->addrlen = sizeof(destination);
+  std::memset(&address->addr, 0, sizeof(address->addr));
+  std::memcpy(&address->addr, &destination, sizeof(destination));
+  return true;
+}
+
+/// Create both server transfer IDs before returning curl's client socket. The
+/// first response deliberately comes from a port different from the rewritten
+/// request destination, matching real TFTP and making curl's address-pinning
+/// transition observable through where its next ACK/DATA arrives.
+curl_socket_t TftpMockServer::HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) {
+  if (purpose != CURLSOCKTYPE_IPCXN || address == nullptr || socket_opened_) {
+    return CURL_SOCKET_BAD;
+  }
+  socket_opened_ = true;
+
+  struct sockaddr_in request_address = {};
+  struct sockaddr_in transfer_address = {};
+  request_fd_ = OpenLoopbackSocket(&request_address);
+  transfer_fd_ = OpenLoopbackSocket(&transfer_address);
+  if (request_fd_ < 0 || transfer_fd_ < 0 || !RewriteDestination(address, request_address)) {
+    ResetPeer();
+    return CURL_SOCKET_BAD;
+  }
+
+  request_port_ = ntohs(request_address.sin_port);
+  transfer_port_ = ntohs(transfer_address.sin_port);
+
+  const int client_fd = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (client_fd < 0 || !ConfigureSocket(client_fd)) {
+    if (client_fd >= 0) {
+      (void)::close(client_fd);
+    }
+    ResetPeer();
+    return CURL_SOCKET_BAD;
+  }
+  return static_cast<curl_socket_t>(client_fd);
+}
+
+/// Pin the first IPv4 client endpoint. Later packets are still captured, but
+/// they cannot redirect scripted responses; otherwise a mutation could make the
+/// harness accept source changes that curl's own TFTP implementation rejects.
+void TftpMockServer::RememberClientAddress(const struct sockaddr_in& address, socklen_t length) {
+  if (has_client_address_ || length != sizeof(address) || address.sin_family != AF_INET) {
+    return;
+  }
+  client_address_ = address;
+  client_address_length_ = length;
+  has_client_address_ = true;
+}
+
+/// Drain until EAGAIN so curl never experiences harness-created UDP receive
+/// backpressure. A 65,536-byte buffer covers the maximum IPv4 UDP payload, and
+/// recvfrom preserves even zero-length datagrams as one state-machine event.
+std::size_t TftpMockServer::DrainSocket(int fd, TftpSocketRole role) {
+  if (fd < 0) {
+    return 0;
+  }
+
+  std::array<unsigned char, 65536> packet;
+  std::size_t count = 0;
+  while (true) {
+    struct sockaddr_in source = {};
+    socklen_t source_length = sizeof(source);
+    const ssize_t received =
+        ::recvfrom(fd, packet.data(), packet.size(), 0, reinterpret_cast<struct sockaddr*>(&source), &source_length);
+    if (received < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+
+    ++count;
+    RememberClientAddress(source, source_length);
+    if (received_datagrams_.size() < kMaxCapturedDatagrams) {
+      TftpReceivedDatagram observation;
+      observation.received_on = role;
+      observation.source_port =
+          source_length == sizeof(source) && source.sin_family == AF_INET ? ntohs(source.sin_port) : 0;
+      observation.bytes.assign(reinterpret_cast<const char*>(packet.data()), static_cast<std::size_t>(received));
+      received_datagrams_.push_back(std::move(observation));
+    }
+  }
+  return count;
+}
+
+/// Drain the well-known request endpoint first because it is the only valid
+/// source of the initial client address. Once a response selects the transfer
+/// endpoint, draining both remains cheap and captures protocol mistakes without
+/// allowing either queue to survive into a later fuzz iteration.
+std::size_t TftpMockServer::DrainClientDatagrams() {
+  return DrainSocket(request_fd_, TftpSocketRole::kRequest) + DrainSocket(transfer_fd_, TftpSocketRole::kTransfer);
+}
+
+/// Consume exactly one script boundary per curl turn. Sending from the transfer
+/// endpoint rather than the request endpoint is what makes subsequent client
+/// traffic prove curl accepted the peer's new TFTP transfer ID.
+bool TftpMockServer::SendNextDatagram() {
+  if (!has_client_address_ || transfer_fd_ < 0 || next_response_datagram_ >= response_datagram_count_) {
+    return false;
+  }
+
+  const std::string& datagram = *response_datagrams_[next_response_datagram_++];
+  (void)::sendto(transfer_fd_, datagram.data(), datagram.size(), 0,
+                 reinterpret_cast<const struct sockaddr*>(&client_address_), client_address_length_);
+  return true;
+}
+
+/// Give curl one nonblocking state-machine turn, retain all client packets that
+/// turn produced, then release at most one peer packet. Completion gets one
+/// final drain so the terminal ACK remains observable. Incomplete scripts stop
+/// after a small idle prefix rather than waiting for TFTP's one-second retry
+/// clock, keeping mutation throughput independent of wall time.
+void TftpMockServer::RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) {
+  (void)easy;
+  ResetPeer();
+  PrepareScript(scenario.connection());
+  received_datagrams_.clear();
+  received_datagrams_.reserve(kMaxCapturedDatagrams);
+
+  int still_running = 1;
+  int idle_iterations = 0;
+  for (int iteration = 0; iteration < kMaxDriveIterations; ++iteration) {
+    const CURLMcode result = curl_multi_perform(multi, &still_running);
+    if (result != CURLM_OK) {
+      break;
+    }
+
+    const bool received = DrainClientDatagrams() != 0;
+    const bool sent = still_running != 0 && received && SendNextDatagram();
+    if (received || sent) {
+      idle_iterations = 0;
+    } else {
+      ++idle_iterations;
+    }
+
+    if (still_running == 0 || idle_iterations >= kMaxIdleIterations) {
+      break;
+    }
+  }
+}
+
+}  // namespace proto_fuzzer

--- a/proto_fuzzer/tftp_mock_server.h
+++ b/proto_fuzzer/tftp_mock_server.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+/// @file
+/// @brief Bounded loopback UDP peer for structured TFTP scenarios.
+
+#ifndef PROTO_FUZZER_TFTP_MOCK_SERVER_H_
+#define PROTO_FUZZER_TFTP_MOCK_SERVER_H_
+
+#include <netinet/in.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "curl_fuzzer.pb.h"
+#include "proto_fuzzer/mock_server_base.h"
+#include "proto_fuzzer/scenario_limits.h"
+
+namespace proto_fuzzer {
+
+/// Identifies which stable server transfer ID received a client datagram.
+/// Tests use this distinction to prove that curl moves from the well-known
+/// request endpoint to the transfer endpoint selected by the first reply.
+enum class TftpSocketRole {
+  kRequest,   ///< Endpoint placed in curl's rewritten destination address.
+  kTransfer,  ///< Endpoint used for replies and the rest of the exchange.
+};
+
+/// One bounded observation of a datagram curl sent to the in-process peer.
+/// Keeping observations on the server object avoids callbacks or globals in
+/// protocol tests, while the fixed count cap prevents a malformed exchange
+/// from retaining traffic in proportion to the drive-loop budget.
+struct TftpReceivedDatagram {
+  TftpSocketRole received_on;  ///< Server endpoint that received the packet.
+  std::uint16_t source_port;   ///< Curl's UDP transfer ID in host byte order.
+  std::string bytes;           ///< Complete UDP payload, including TFTP header.
+};
+
+/// @class proto_fuzzer::TftpMockServer
+/// @brief Real, nonblocking UDP peer for curl's TFTP state machine.
+///
+/// An AF_UNIX socketpair cannot model TFTP: curl binds the returned descriptor
+/// as an IP datagram socket and uses sendto/recvfrom with a mutable transfer
+/// address. This peer binds two ephemeral loopback endpoints. The request
+/// endpoint receives RRQ/WRQ, while every response originates at the transfer
+/// endpoint so curl exercises the RFC transfer-ID pinning path.
+///
+/// `Connection.initial_response`, when nonempty, is the first response
+/// datagram. Each retained `Connection.on_readable` value is one subsequent
+/// datagram, including an explicitly empty value. A single datagram is released
+/// after each curl state-machine turn, which preserves packet boundaries and
+/// permits duplicates, unexpected blocks, and malformed packets without a
+/// thread or wall-clock wait.
+class TftpMockServer final : public MockServerBase {
+ public:
+  TftpMockServer();
+  ~TftpMockServer() override;
+
+  TftpMockServer(const TftpMockServer&) = delete;
+  TftpMockServer& operator=(const TftpMockServer&) = delete;
+
+  /// Return the bounded client datagrams observed during the most recent run.
+  /// @return Borrowed observations that remain valid until the next drive or
+  ///         destruction of this server.
+  const std::vector<TftpReceivedDatagram>& received_datagrams() const;
+
+  /// Expose the request endpoint for transfer-ID assertions, not for routing.
+  /// @return request UDP port in host byte order, or zero before socket setup.
+  std::uint16_t request_port() const;
+
+  /// Expose the response endpoint for transfer-ID assertions, not for routing.
+  /// @return transfer UDP port in host byte order, or zero before socket setup.
+  std::uint16_t transfer_port() const;
+
+ protected:
+  /// Create the real UDP client descriptor and replace curl's destination with
+  /// the private request endpoint. Curl owns a successful return value.
+  /// @param purpose Socket purpose supplied by curl's open-socket callback.
+  /// @param address Mutable destination storage supplied by curl.
+  /// @return client UDP descriptor, or CURL_SOCKET_BAD on setup failure.
+  curl_socket_t HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) override;
+
+  /// Alternate curl and peer state-machine turns without blocking. This makes
+  /// packet ordering deterministic and lets incomplete scripts terminate by an
+  /// operation/idle budget instead of curl's wall-clock TFTP retransmit timer.
+  /// @param multi Multi handle containing the scenario's easy handle.
+  /// @param easy Easy handle being driven; all work is reached through multi.
+  /// @param scenario Scenario whose primary Connection supplies UDP packets.
+  void RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) override;
+
+ private:
+  /// One client packet can follow the initial request and every retained server
+  /// packet. Capturing anything beyond that useful prefix would make test-only
+  /// observation memory follow malformed retry traffic rather than coverage.
+  static constexpr std::size_t kMaxCapturedDatagrams = scenario_limits::kMaxResponseChunks + 2;
+
+  /// Build the borrowed response-pointer table before curl can open a socket.
+  /// @param connection Primary connection whose packet boundaries are retained.
+  void PrepareScript(const curl::fuzzer::proto::Connection& connection);
+
+  /// Close only server-owned sockets and clear address/routing state. The
+  /// returned client descriptor is deliberately absent because curl owns it.
+  void ResetPeer();
+
+  /// Set nonblocking and close-on-exec explicitly because callback-created
+  /// descriptors cannot rely on curl's native socket() flags.
+  /// @param fd Descriptor to configure.
+  /// @return true only when both descriptor invariants were established.
+  static bool ConfigureSocket(int fd);
+
+  /// Bind one IPv4 UDP endpoint to an ephemeral loopback port.
+  /// @param bound_address Receives the exact address selected by the kernel.
+  /// @return owned descriptor, or -1 after closing any failed descriptor.
+  static int OpenLoopbackSocket(struct sockaddr_in* bound_address);
+
+  /// Replace every destination field curl may retain, preventing a mutated URL
+  /// from selecting a real network endpoint after the callback returns.
+  /// @param address Mutable callback address to rewrite.
+  /// @param destination Bound request endpoint to install.
+  /// @return true when the public address storage can represent IPv4 safely.
+  static bool RewriteDestination(struct curl_sockaddr* address, const struct sockaddr_in& destination);
+
+  /// Drain all immediately available packets from one server endpoint.
+  /// @param fd Nonblocking server descriptor to read.
+  /// @param role Which endpoint the descriptor represents.
+  /// @return number of datagrams consumed, including zero-length datagrams.
+  std::size_t DrainSocket(int fd, TftpSocketRole role);
+
+  /// Drain request and transfer endpoints so neither valid uploads nor
+  /// retransmissions can fill a kernel queue between curl turns.
+  /// @return total number of client datagrams consumed.
+  std::size_t DrainClientDatagrams();
+
+  /// Retain only the first valid client address as the transfer destination.
+  /// TFTP's transfer ID must stay stable; accepting later source changes would
+  /// hide the very address-pinning behavior the peer is meant to exercise.
+  /// @param address Source address returned by recvfrom.
+  /// @param length Number of valid bytes in address.
+  void RememberClientAddress(const struct sockaddr_in& address, socklen_t length);
+
+  /// Release one scripted packet from the transfer endpoint. UDP sends are
+  /// atomic, so an error consumes the entry instead of retrying in a hot loop.
+  /// @return true when a script entry was consumed, regardless of send result.
+  bool SendNextDatagram();
+
+  std::array<const std::string*, scenario_limits::kMaxResponseChunks + 1> response_datagrams_;
+  std::size_t response_datagram_count_;
+  std::size_t next_response_datagram_;
+
+  int request_fd_;
+  int transfer_fd_;
+  struct sockaddr_in client_address_;
+  socklen_t client_address_length_;
+  bool has_client_address_;
+  bool socket_opened_;
+  std::uint16_t request_port_;
+  std::uint16_t transfer_port_;
+  std::vector<TftpReceivedDatagram> received_datagrams_;
+};
+
+}  // namespace proto_fuzzer
+
+#endif  // PROTO_FUZZER_TFTP_MOCK_SERVER_H_

--- a/proto_fuzzer/websocket_mock_server.cc
+++ b/proto_fuzzer/websocket_mock_server.cc
@@ -257,9 +257,15 @@ void WebSocketMockServer::ConsumeChunk() {
 /// Called by the OPENSOCKETFUNCTION trampoline in the base class. Creates the
 /// MockConnection but does NOT write anything — the handshake is driven later
 /// by TryAdvanceHandshake().
+/// @param purpose Socket role requested by curl; this peer accepts one outbound
+///                WebSocket transport only.
+/// @param address Intended destination retained by curl; the already-connected
+///                socketpair leaves it unchanged.
 /// @return the client-side fd to hand to libcurl, or CURL_SOCKET_BAD on
 ///         failure.
-curl_socket_t WebSocketMockServer::HandleOpenSocket() {
+curl_socket_t WebSocketMockServer::HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) {
+  (void)purpose;
+  (void)address;
   if (connection_) {
     return CURL_SOCKET_BAD;
   }

--- a/proto_fuzzer/websocket_mock_server.h
+++ b/proto_fuzzer/websocket_mock_server.h
@@ -68,7 +68,8 @@ class WebSocketMockServer : public MockServerBase {
   bool PushRawBytes(const unsigned char* data, std::size_t size);
 
  protected:
-  curl_socket_t HandleOpenSocket() override;
+  curl_socket_t HandleOpenSocket(curlsocktype purpose = CURLSOCKTYPE_IPCXN,
+                                 struct curl_sockaddr* address = nullptr) override;
   void RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) override;
 
  public:

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_account_login.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_account_login.textproto
@@ -1,0 +1,17 @@
+# A 332 PASS response makes curl issue ACCT using the copied account option.
+scheme: SCHEME_FTP
+host_path: "ftp.test/accounted"
+options { option_id: CURLOPT_FTP_ACCOUNT string_value: "project" }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password required\r\n"
+  on_readable: "332 account required\r\n"
+  on_readable: "230 account accepted\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 binary\r\n"
+  on_readable: "213 1\r\n"
+  on_readable: "150 data\r\n"
+  on_readable: "226 done\r\n"
+}
+subsequent_connections { initial_response: "x" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_alternative_user.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_alternative_user.textproto
@@ -1,0 +1,17 @@
+# A rejected USER makes curl issue the configured alternative login command;
+# accepting that command resumes the ordinary PWD and download state machine.
+scheme: SCHEME_FTP
+host_path: "ftp.test/alternative.bin"
+options { option_id: CURLOPT_FTP_ALTERNATIVE_TO_USER string_value: "SITE LOGIN" }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "530 USER rejected\r\n"
+  on_readable: "230 alternative accepted\r\n"
+  on_readable: "257 \"/\" is current directory\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 binary type selected\r\n"
+  on_readable: "213 3\r\n"
+  on_readable: "150 opening data\r\n"
+  on_readable: "226 transfer complete\r\n"
+}
+subsequent_connections { initial_response: "alt" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_completion_eof.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_completion_eof.textproto
@@ -1,0 +1,16 @@
+# An explicitly empty final response half-closes the control peer after data
+# EOF, reaching curl's missing-transfer-completion handling without a timeout.
+scheme: SCHEME_FTP
+host_path: "ftp.test/file"
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 logged in\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 binary\r\n"
+  on_readable: "213 4\r\n"
+  on_readable: "150 data\r\n"
+  on_readable: ""
+}
+subsequent_connections { initial_response: "body" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_create_directories.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_create_directories.textproto
@@ -1,0 +1,24 @@
+# CWD failure followed by MKD/CWD drives missing-directory recovery.
+scheme: SCHEME_FTP
+host_path: "ftp.test/a/b/file"
+options { option_id: CURLOPT_UPLOAD bool_value: true }
+options { option_id: CURLOPT_INFILESIZE_LARGE uint_value: 1 }
+options { option_id: CURLOPT_FTP_CREATE_MISSING_DIRS uint_value: 2 }
+upload { data: "x" terminal: UPLOAD_TERMINAL_EOF }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 ok\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "550 missing a\r\n"
+  on_readable: "257 a created\r\n"
+  on_readable: "250 cwd a\r\n"
+  on_readable: "550 missing b\r\n"
+  on_readable: "257 b created\r\n"
+  on_readable: "250 cwd b\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 binary\r\n"
+  on_readable: "150 storing\r\n"
+  on_readable: "226 stored\r\n"
+}
+subsequent_connections {}

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_custom_list.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_custom_list.textproto
@@ -1,0 +1,17 @@
+# A custom directory command keeps CURLOPT_CUSTOMREQUEST mutations on the
+# passive-data path even when the verb is not one of curl's usual LIST forms.
+scheme: SCHEME_FTP
+host_path: "ftp.test/"
+options { option_id: CURLOPT_DIRLISTONLY bool_value: true }
+options { option_id: CURLOPT_CUSTOMREQUEST string_value: "X-LIST" }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 logged in\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 binary\r\n"
+  on_readable: "150 custom listing\r\n"
+  on_readable: "226 listed\r\n"
+}
+subsequent_connections { initial_response: "custom-entry\r\n" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_epsv_retr.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_epsv_retr.textproto
@@ -1,0 +1,18 @@
+# Complete passive download: login, PWD, EPSV, TYPE, SIZE, RETR, data EOF,
+# then the final control-channel completion reply.
+scheme: SCHEME_FTP
+host_path: "ftp.test/file.bin"
+options { option_id: CURLOPT_USERNAME string_value: "fuzz" }
+options { option_id: CURLOPT_PASSWORD string_value: "secret" }
+connection {
+  initial_response: "220 ftp fuzz peer ready\r\n"
+  on_readable: "331 password required\r\n"
+  on_readable: "230 logged in\r\n"
+  on_readable: "257 \"/\" is current directory\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||12345|)\r\n"
+  on_readable: "200 type set\r\n"
+  on_readable: "213 11\r\n"
+  on_readable: "150 opening data connection\r\n"
+  on_readable: "226 transfer complete\r\n"
+}
+subsequent_connections { initial_response: "hello world" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_list.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_list.textproto
@@ -1,0 +1,17 @@
+# A directory transfer reaches LIST/NLST parsing and the passive data channel.
+scheme: SCHEME_FTP
+host_path: "ftp.test/pub/"
+options { option_id: CURLOPT_DIRLISTONLY bool_value: true }
+options { option_id: CURLOPT_TRANSFERTEXT bool_value: true }
+connection {
+  initial_response: "220-list peer\r\n220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 ok\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "250 cwd pub\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 ascii\r\n"
+  on_readable: "150 listing\r\n"
+  on_readable: "226 listed\r\n"
+}
+subsequent_connections { initial_response: "alpha\r\nbeta\r\n" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_metadata_head.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_metadata_head.textproto
@@ -1,0 +1,16 @@
+# A metadata-only request traverses MDTM date parsing, TYPE/SIZE handling and
+# REST capability probing without opening a passive data connection.
+scheme: SCHEME_FTP
+host_path: "ftp.test/metadata.bin"
+options { option_id: CURLOPT_NOBODY bool_value: true }
+options { option_id: CURLOPT_FILETIME bool_value: true }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password required\r\n"
+  on_readable: "230 logged in\r\n"
+  on_readable: "257 \"/\" is current directory\r\n"
+  on_readable: "213 20260830123456\r\n"
+  on_readable: "200 binary type selected\r\n"
+  on_readable: "213 42\r\n"
+  on_readable: "350 restart supported\r\n"
+}

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_pasv_fallback.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_pasv_fallback.textproto
@@ -1,0 +1,16 @@
+# Reject EPSV so curl falls back through its PASV parser before downloading.
+scheme: SCHEME_FTP
+host_path: "ftp.test/fallback"
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 welcome\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "500 EPSV unsupported\r\n"
+  on_readable: "227 Entering Passive Mode (127,0,0,1,48,57)\r\n"
+  on_readable: "200 binary\r\n"
+  on_readable: "213 8\r\n"
+  on_readable: "150 data follows\r\n"
+  on_readable: "226 done\r\n"
+}
+subsequent_connections { initial_response: "fallback" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_resume_pret.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_resume_pret.textproto
@@ -1,0 +1,20 @@
+# PRET, SIZE and REST are command-generating branches that need correlated
+# success replies before RETR can reach the data state.
+scheme: SCHEME_FTP
+host_path: "ftp.test/resume.bin"
+options { option_id: CURLOPT_FTP_USE_PRET bool_value: true }
+options { option_id: CURLOPT_RESUME_FROM_LARGE uint_value: 4 }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 ok\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "200 PRET accepted\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 binary\r\n"
+  on_readable: "213 12\r\n"
+  on_readable: "350 restart accepted\r\n"
+  on_readable: "150 partial data\r\n"
+  on_readable: "226 complete\r\n"
+}
+subsequent_connections { initial_response: "56789012" }

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_upload_append.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_upload_append.textproto
@@ -1,0 +1,18 @@
+# APPE takes a distinct command/state path from ordinary STOR.
+scheme: SCHEME_FTP
+host_path: "ftp.test/log.txt"
+options { option_id: CURLOPT_UPLOAD bool_value: true }
+options { option_id: CURLOPT_APPEND bool_value: true }
+options { option_id: CURLOPT_INFILESIZE_LARGE uint_value: 6 }
+upload { data: "append" terminal: UPLOAD_TERMINAL_EOF }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 ok\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 ascii\r\n"
+  on_readable: "150 append data\r\n"
+  on_readable: "226 appended\r\n"
+}
+subsequent_connections {}

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_upload_stor.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_upload_stor.textproto
@@ -1,0 +1,22 @@
+# Callback-backed STOR covers the FTP upload state machine and data drain.
+scheme: SCHEME_FTP
+host_path: "ftp.test/upload.bin"
+options { option_id: CURLOPT_UPLOAD bool_value: true }
+options { option_id: CURLOPT_INFILESIZE_LARGE uint_value: 12 }
+upload {
+  data: "upload-bytes"
+  read_sizes: 3
+  read_sizes: 4
+  terminal: UPLOAD_TERMINAL_EOF
+}
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password\r\n"
+  on_readable: "230 ok\r\n"
+  on_readable: "257 \"/\"\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||12345|)\r\n"
+  on_readable: "200 binary\r\n"
+  on_readable: "150 receive data\r\n"
+  on_readable: "226 stored\r\n"
+}
+subsequent_connections {}

--- a/scenarios/curl_fuzzer_proto/ftp/ftp_wildcard_retr.textproto
+++ b/scenarios/curl_fuzzer_proto/ftp/ftp_wildcard_retr.textproto
@@ -1,0 +1,24 @@
+# Wildcard matching first parses a directory listing, then reuses the control
+# connection for a second passive transfer of the matching regular file.
+scheme: SCHEME_FTP
+host_path: "ftp.test/pub/*.txt"
+options { option_id: CURLOPT_WILDCARDMATCH bool_value: true }
+connection {
+  initial_response: "220 ready\r\n"
+  on_readable: "331 password required\r\n"
+  on_readable: "230 logged in\r\n"
+  on_readable: "257 \"/\" is current directory\r\n"
+  on_readable: "250 changed to pub\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1025|)\r\n"
+  on_readable: "200 ASCII type selected\r\n"
+  on_readable: "150 opening listing\r\n"
+  on_readable: "226 listing complete\r\n"
+  on_readable: "229 Entering Extended Passive Mode (|||1026|)\r\n"
+  on_readable: "200 binary type selected\r\n"
+  on_readable: "150 opening match.txt\r\n"
+  on_readable: "226 file complete\r\n"
+}
+subsequent_connections {
+  initial_response: "-rw-r--r-- 1 ftp ftp 5 Apr 27 11:01 match.txt\r\n"
+}
+subsequent_connections { initial_response: "match" }

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_duplicate_data.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_duplicate_data.textproto
@@ -1,0 +1,10 @@
+# Duplicate DATA1 must be acknowledged without delivering its body twice.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/duplicate"
+options { option_id: CURLOPT_TFTP_BLKSIZE uint_value: 8 }
+connection {
+  initial_response: "\000\006blksize\0008\000"
+  on_readable: "\000\003\000\001abcdefgh"
+  on_readable: "\000\003\000\001abcdefgh"
+  on_readable: "\000\003\000\002z"
+}

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_error_not_found.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_error_not_found.textproto
@@ -1,0 +1,4 @@
+# ERROR code 1 maps to CURLE_TFTP_NOTFOUND and exercises message parsing.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/missing"
+connection { initial_response: "\000\005\000\001not found\000" }

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_malformed_oack.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_malformed_oack.textproto
@@ -1,0 +1,5 @@
+# Missing OACK value/terminator reaches negotiation rejection without waiting.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/bad-options"
+options { option_id: CURLOPT_TFTP_BLKSIZE uint_value: 8 }
+connection { initial_response: "\000\006blksize\000" }

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_netascii.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_netascii.textproto
@@ -1,0 +1,6 @@
+# URL mode parsing and text transfer select TFTP's netascii request spelling.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/text;mode=netascii"
+options { option_id: CURLOPT_TRANSFERTEXT bool_value: true }
+options { option_id: CURLOPT_TFTP_NO_OPTIONS bool_value: true }
+connection { initial_response: "\000\003\000\001line\r\n" }

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_rrq_no_options.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_rrq_no_options.textproto
@@ -1,0 +1,5 @@
+# A short DATA block completes a no-options RRQ in one round trip.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/file"
+options { option_id: CURLOPT_TFTP_NO_OPTIONS bool_value: true }
+connection { initial_response: "\000\003\000\001hello" }

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_rrq_oack_multiblock.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_rrq_oack_multiblock.textproto
@@ -1,0 +1,9 @@
+# Negotiate an eight-byte block, then finish with a short second DATA packet.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/multiblock"
+options { option_id: CURLOPT_TFTP_BLKSIZE uint_value: 8 }
+connection {
+  initial_response: "\000\006blksize\0008\000tsize\00011\000"
+  on_readable: "\000\003\000\001abcdefgh"
+  on_readable: "\000\003\000\002ijk"
+}

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_rrq_options_ignored.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_rrq_options_ignored.textproto
@@ -1,0 +1,7 @@
+# A server may ignore the requested options and answer RRQ with DATA1. The
+# eight-byte body is terminal only if curl correctly falls back from the
+# requested eight-byte block size to TFTP's 512-byte default.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/options-ignored"
+options { option_id: CURLOPT_TFTP_BLKSIZE uint_value: 8 }
+connection { initial_response: "\000\003\000\001abcdefgh" }

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_short_packet_retry.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_short_packet_retry.textproto
@@ -1,0 +1,9 @@
+# A too-short packet synthesizes the same timeout event used by retransmission,
+# allowing that state transition to be fuzzed without a wall-clock sleep.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/retry"
+options { option_id: CURLOPT_TFTP_NO_OPTIONS bool_value: true }
+connection {
+  initial_response: "\000"
+  on_readable: "\000\003\000\001ok"
+}

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_wrq_no_options.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_wrq_no_options.textproto
@@ -1,0 +1,11 @@
+# ACK0 starts a no-options upload and ACK1 completes its short DATA1 block.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/upload"
+options { option_id: CURLOPT_UPLOAD bool_value: true }
+options { option_id: CURLOPT_INFILESIZE_LARGE uint_value: 6 }
+options { option_id: CURLOPT_TFTP_NO_OPTIONS bool_value: true }
+upload { data: "upload" read_sizes: 2 terminal: UPLOAD_TERMINAL_EOF }
+connection {
+  initial_response: "\000\004\000\000"
+  on_readable: "\000\004\000\001"
+}

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_wrq_oack_exact_block.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_wrq_oack_exact_block.textproto
@@ -1,0 +1,12 @@
+# An exact negotiated block forces curl to send an empty terminal DATA2 packet.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/exact"
+options { option_id: CURLOPT_UPLOAD bool_value: true }
+options { option_id: CURLOPT_INFILESIZE_LARGE uint_value: 8 }
+options { option_id: CURLOPT_TFTP_BLKSIZE uint_value: 8 }
+upload { data: "12345678" terminal: UPLOAD_TERMINAL_EOF }
+connection {
+  initial_response: "\000\006blksize\0008\000tsize\0008\000"
+  on_readable: "\000\004\000\001"
+  on_readable: "\000\004\000\002"
+}

--- a/scenarios/curl_fuzzer_proto/tftp/tftp_wrq_options_ignored_retry.textproto
+++ b/scenarios/curl_fuzzer_proto/tftp/tftp_wrq_options_ignored_retry.textproto
@@ -1,0 +1,16 @@
+# ACK0 makes an option-bearing WRQ fall back to the default block size. A
+# mismatched ACK then makes curl retransmit DATA1 before the correct ACK1.
+# The request-driven peer can faithfully model this retry; recovery after an
+# unsolicited out-of-order DATA packet or a foreign transfer ID needs packet
+# source/timing metadata that the current Connection script does not carry.
+scheme: SCHEME_TFTP
+host_path: "tftp.test/options-ignored-retry"
+options { option_id: CURLOPT_UPLOAD bool_value: true }
+options { option_id: CURLOPT_INFILESIZE_LARGE uint_value: 8 }
+options { option_id: CURLOPT_TFTP_BLKSIZE uint_value: 8 }
+upload { data: "abcdefgh" terminal: UPLOAD_TERMINAL_EOF }
+connection {
+  initial_response: "\000\004\000\000"
+  on_readable: "\000\004\000\002"
+  on_readable: "\000\004\000\001"
+}

--- a/schemas/curl_fuzzer.proto
+++ b/schemas/curl_fuzzer.proto
@@ -207,6 +207,10 @@ enum Scheme {
   SCHEME_WS = 3;
   SCHEME_WSS = 4;
   SCHEME_TELNET = 5;
+  // Keep new protocols append-only: the compatibility target replays binary
+  // Scenarios accumulated before these dedicated lanes existed.
+  SCHEME_FTP = 6;
+  SCHEME_TFTP = 7;
 }
 
 message SetOption {

--- a/schemas/curl_fuzzer_supported_curlopts.txt
+++ b/schemas/curl_fuzzer_supported_curlopts.txt
@@ -77,3 +77,23 @@ CURLOPT_UPLOAD_BUFFERSIZE
 CURLOPT_MIME_OPTIONS
 CURLOPT_MAXFILESIZE_LARGE
 CURLOPT_BUFFERSIZE
+
+# Plain FTP control/data state. Active-mode FTPPORT/EPRT, FTPS knobs, and
+# slist-backed QUOTE variants stay out until their transports and ownership
+# have protocol-specific peers rather than relying on scalar setopt dispatch.
+CURLOPT_DIRLISTONLY
+CURLOPT_APPEND
+CURLOPT_TRANSFERTEXT
+CURLOPT_FTP_USE_EPSV
+CURLOPT_FTP_CREATE_MISSING_DIRS
+CURLOPT_FTP_ACCOUNT
+CURLOPT_FTP_SKIP_PASV_IP
+CURLOPT_FTP_FILEMETHOD
+CURLOPT_FTP_ALTERNATIVE_TO_USER
+CURLOPT_FTP_USE_PRET
+CURLOPT_WILDCARDMATCH
+
+# TFTP uses the existing upload body and size options. These two switches
+# reach its option-negotiation and raw RRQ/WRQ construction paths.
+CURLOPT_TFTP_BLKSIZE
+CURLOPT_TFTP_NO_OPTIONS

--- a/scripts/compare_fuzzers.py
+++ b/scripts/compare_fuzzers.py
@@ -32,8 +32,10 @@ from typing import IO, Callable, Iterable, Sequence, TypeVar
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_TARGETS = (
+    "curl_fuzzer_ftp",
     "curl_fuzzer_http",
     "curl_fuzzer_https",
+    "curl_fuzzer_tftp",
     "curl_fuzzer_ws",
     "curl_fuzzer_proto_http",
     "curl_fuzzer_proto_http_deep",
@@ -41,6 +43,8 @@ DEFAULT_TARGETS = (
     "curl_fuzzer_proto_ws",
     "curl_fuzzer_proto_wss",
     "curl_fuzzer_proto_telnet",
+    "curl_fuzzer_proto_ftp",
+    "curl_fuzzer_proto_tftp",
     "curl_fuzzer_proto_api",
     "curl_fuzzer_proto_timing",
 )
@@ -52,6 +56,8 @@ HISTORICAL_PROTO_CORPUS_TARGETS = frozenset(
         "curl_fuzzer_proto_ws",
         "curl_fuzzer_proto_wss",
         "curl_fuzzer_proto_telnet",
+        "curl_fuzzer_proto_ftp",
+        "curl_fuzzer_proto_tftp",
         "curl_fuzzer_proto_api",
         "curl_fuzzer_proto_timing",
     }

--- a/scripts/fuzz_corpus_helpers.sh
+++ b/scripts/fuzz_corpus_helpers.sh
@@ -31,7 +31,7 @@ fuzz_local_corpus_dir() {
 fuzz_public_corpus_names() {
     echo "$1"
     case "$1" in
-        curl_fuzzer_proto_http|curl_fuzzer_proto_http_deep|curl_fuzzer_proto_https|curl_fuzzer_proto_ws|curl_fuzzer_proto_wss|curl_fuzzer_proto_telnet|curl_fuzzer_proto_api|curl_fuzzer_proto_timing)
+        curl_fuzzer_proto_http|curl_fuzzer_proto_http_deep|curl_fuzzer_proto_https|curl_fuzzer_proto_ws|curl_fuzzer_proto_wss|curl_fuzzer_proto_telnet|curl_fuzzer_proto_ftp|curl_fuzzer_proto_tftp|curl_fuzzer_proto_api|curl_fuzzer_proto_timing)
             echo "curl_fuzzer_proto"
             ;;
     esac

--- a/scripts/fuzz_targets
+++ b/scripts/fuzz_targets
@@ -4,7 +4,7 @@ FUZZ_TARGETS_LIST="curl_fuzzer_dict curl_fuzzer_file curl_fuzzer_ftp curl_fuzzer
 
 # The structured fuzzer is 64-bit only.
 if [ "${ARCHITECTURE:-}" != "i386" ]; then
-    FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto curl_fuzzer_proto_http curl_fuzzer_proto_http_deep curl_fuzzer_proto_https curl_fuzzer_proto_ws curl_fuzzer_proto_wss curl_fuzzer_proto_telnet curl_fuzzer_proto_api curl_fuzzer_proto_timing"
+    FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto curl_fuzzer_proto_http curl_fuzzer_proto_http_deep curl_fuzzer_proto_https curl_fuzzer_proto_ws curl_fuzzer_proto_wss curl_fuzzer_proto_telnet curl_fuzzer_proto_ftp curl_fuzzer_proto_tftp curl_fuzzer_proto_api curl_fuzzer_proto_timing"
 fi
 
 export FUZZ_TARGETS="${FUZZ_TARGETS_LIST}"

--- a/src/curl_fuzzer_tools/generate_option_manifest.py
+++ b/src/curl_fuzzer_tools/generate_option_manifest.py
@@ -74,6 +74,14 @@ OPTION_KIND_OVERRIDES: Dict[str, str] = {
     "CURLOPT_SSL_ENABLE_ALPN": "bool",
     "CURLOPT_COOKIESESSION": "bool",
     "CURLOPT_UNRESTRICTED_AUTH": "bool",
+    "CURLOPT_DIRLISTONLY": "bool",
+    "CURLOPT_APPEND": "bool",
+    "CURLOPT_TRANSFERTEXT": "bool",
+    "CURLOPT_FTP_USE_EPSV": "bool",
+    "CURLOPT_FTP_SKIP_PASV_IP": "bool",
+    "CURLOPT_FTP_USE_PRET": "bool",
+    "CURLOPT_WILDCARDMATCH": "bool",
+    "CURLOPT_TFTP_NO_OPTIONS": "bool",
 }
 
 VALUE_KIND_SYMBOLS: Dict[str, str] = {

--- a/tests/curl_features_test.cc
+++ b/tests/curl_features_test.cc
@@ -24,19 +24,32 @@ int main() {
     return 1;
   }
   bool has_telnet = false;
+  bool has_ftp = false;
+  bool has_tftp = false;
   if (info->protocols) {
     for (const char *const *protocol = info->protocols; *protocol; ++protocol) {
       if (std::strcmp(*protocol, "telnet") == 0) {
         has_telnet = true;
-        break;
+      } else if (std::strcmp(*protocol, "ftp") == 0) {
+        has_ftp = true;
+      } else if (std::strcmp(*protocol, "tftp") == 0) {
+        has_tftp = true;
       }
     }
   }
-  // curl exposes no CURL_VERSION_TELNET feature bit. Its advertised protocol
-  // list is therefore the only runtime guard against a future build-default
-  // change silently turning the dedicated proto fuzzer into a no-op error path.
+  // curl exposes no per-protocol feature bits for these handlers. Its
+  // advertised list is therefore the runtime guard against a future default
+  // change silently turning a dedicated fuzzer into a no-op error path.
   if (!has_telnet) {
     std::fputs("libcurl was built without TELNET support\n", stderr);
+    return 1;
+  }
+  if (!has_ftp) {
+    std::fputs("libcurl was built without FTP support\n", stderr);
+    return 1;
+  }
+  if (!has_tftp) {
+    std::fputs("libcurl was built without TFTP support\n", stderr);
     return 1;
   }
   return 0;

--- a/tests/ftp_mock_server_test.cc
+++ b/tests/ftp_mock_server_test.cc
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include <curl/curl.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "curl_fuzzer.pb.h"
+#include "proto_fuzzer/ftp_mock_server.h"
+#include "proto_fuzzer/option_apply.h"
+#include "proto_fuzzer/request_data.h"
+
+namespace {
+
+using curl::fuzzer::proto::Scenario;
+
+struct CurlEasyDeleter {
+  void operator()(CURL *easy) const { curl_easy_cleanup(easy); }
+};
+
+struct CurlSlistDeleter {
+  void operator()(curl_slist *list) const { curl_slist_free_all(list); }
+};
+
+using CurlEasyPtr = std::unique_ptr<CURL, CurlEasyDeleter>;
+using CurlSlistPtr = std::unique_ptr<curl_slist, CurlSlistDeleter>;
+
+void Fail(const char *message) {
+  std::cerr << message << '\n';
+  std::exit(1);
+}
+
+void Expect(bool condition, const char *message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+size_t CollectResponse(char *contents, size_t size, size_t nmemb,
+                       void *userdata) {
+  const size_t bytes = size * nmemb;
+  static_cast<std::string *>(userdata)->append(contents, bytes);
+  return bytes;
+}
+
+struct FtpRunResult {
+  CURLcode code = CURLE_FAILED_INIT;
+  std::string body;
+  std::string transcript;
+  std::string uploaded;
+  std::size_t data_connections = 0;
+};
+
+FtpRunResult RunScenario(const Scenario &scenario, const char *url) {
+  FtpRunResult result;
+  CurlEasyPtr easy(curl_easy_init());
+  Expect(easy != nullptr, "curl_easy_init failed");
+  CurlSlistPtr connect_to(proto_fuzzer::ApplyBaselineOptions(
+      easy.get(), curl::fuzzer::proto::SCHEME_FTP));
+  Expect(connect_to != nullptr, "FTP baseline did not create CONNECT_TO state");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_URL, url) == CURLE_OK,
+         "FTP URL setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_WRITEFUNCTION,
+                          &CollectResponse) == CURLE_OK,
+         "FTP write callback setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_WRITEDATA, &result.body) ==
+             CURLE_OK,
+         "FTP write data setup failed");
+  (void)proto_fuzzer::ApplyScenarioOptions(easy.get(), scenario);
+
+  proto_fuzzer::FtpMockServer server;
+  server.Install(easy.get());
+  {
+    proto_fuzzer::ScenarioRequestData request_data(easy.get(), scenario);
+    result.code = server.DriveScenario(easy.get(), scenario);
+  }
+  result.transcript = server.control_transcript();
+  result.uploaded = server.uploaded_data();
+  result.data_connections = server.opened_data_connection_count();
+
+  // CONNECT_TO storage must remain valid through easy cleanup.
+  easy.reset();
+  connect_to.reset();
+  return result;
+}
+
+void AddLoginAndPwdReplies(Scenario *scenario) {
+  auto *connection = scenario->mutable_connection();
+  connection->set_initial_response("220 ready\r\n");
+  connection->add_on_readable("331 password required\r\n");
+  connection->add_on_readable("230 logged in\r\n");
+  connection->add_on_readable("257 \"/\" is current directory\r\n");
+}
+
+void TestEpsvDownloadAndFinalReply() {
+  Scenario scenario;
+  AddLoginAndPwdReplies(&scenario);
+  auto *control = scenario.mutable_connection();
+  control->add_on_readable(
+      "229 Entering Extended Passive Mode (|||12345|)\r\n");
+  control->add_on_readable("200 type set\r\n");
+  control->add_on_readable("213 11\r\n");
+  control->add_on_readable("150 opening data\r\n");
+  control->add_on_readable("226 complete\r\n");
+  scenario.add_subsequent_connections()->set_initial_response("hello world");
+
+  const FtpRunResult result = RunScenario(scenario, "ftp://ftp.test/file.bin");
+  Expect(result.code == CURLE_OK, "EPSV FTP download did not complete");
+  Expect(result.body == "hello world",
+         "EPSV FTP download produced the wrong body");
+  Expect(result.data_connections == 1,
+         "EPSV FTP download did not open exactly one data socket");
+  Expect(result.transcript.find("EPSV\r\n") != std::string::npos,
+         "FTP download did not issue EPSV");
+  Expect(result.transcript.find("RETR file.bin\r\n") != std::string::npos,
+         "FTP download did not issue RETR");
+}
+
+void TestEpsvFailureFallsBackToPasv() {
+  Scenario scenario;
+  AddLoginAndPwdReplies(&scenario);
+  auto *control = scenario.mutable_connection();
+  control->add_on_readable("500 no EPSV\r\n");
+  control->add_on_readable("227 Entering Passive Mode (127,0,0,1,48,57)\r\n");
+  control->add_on_readable("200 type set\r\n");
+  control->add_on_readable("213 8\r\n");
+  control->add_on_readable("150 opening data\r\n");
+  control->add_on_readable("226 complete\r\n");
+  scenario.add_subsequent_connections()->set_initial_response("fallback");
+
+  const FtpRunResult result = RunScenario(scenario, "ftp://ftp.test/fallback");
+  Expect(result.code == CURLE_OK, "FTP PASV fallback did not complete");
+  Expect(result.body == "fallback",
+         "FTP PASV fallback produced the wrong body");
+  Expect(result.transcript.find("EPSV\r\n") != std::string::npos,
+         "FTP PASV fallback skipped EPSV attempt");
+  Expect(result.transcript.find("PASV\r\n") != std::string::npos,
+         "FTP EPSV rejection did not issue PASV");
+}
+
+void TestUploadIsDrainedWithoutLosingControlChannel() {
+  Scenario scenario;
+  auto *upload_option = scenario.add_options();
+  upload_option->set_option_id(curl::fuzzer::proto::CURLOPT_UPLOAD);
+  upload_option->set_bool_value(true);
+  auto *size_option = scenario.add_options();
+  size_option->set_option_id(curl::fuzzer::proto::CURLOPT_INFILESIZE_LARGE);
+  size_option->set_uint_value(12);
+  scenario.mutable_upload()->set_data("upload-bytes");
+  scenario.mutable_upload()->add_read_sizes(3);
+  scenario.mutable_upload()->add_read_sizes(4);
+  AddLoginAndPwdReplies(&scenario);
+  auto *control = scenario.mutable_connection();
+  control->add_on_readable(
+      "229 Entering Extended Passive Mode (|||12345|)\r\n");
+  control->add_on_readable("200 type set\r\n");
+  control->add_on_readable("150 send data\r\n");
+  control->add_on_readable("226 stored\r\n");
+  scenario.add_subsequent_connections();
+
+  const FtpRunResult result =
+      RunScenario(scenario, "ftp://ftp.test/upload.bin");
+  Expect(result.code == CURLE_OK, "FTP upload did not complete");
+  Expect(result.uploaded == "upload-bytes",
+         "FTP peer did not drain the exact upload body");
+  Expect(result.transcript.find("STOR upload.bin\r\n") != std::string::npos,
+         "FTP upload did not issue STOR");
+  Expect(result.data_connections == 1,
+         "FTP upload did not open exactly one passive socket");
+}
+
+void TestCustomListingCommandReceivesPassiveData() {
+  Scenario scenario;
+  auto *list_only = scenario.add_options();
+  list_only->set_option_id(curl::fuzzer::proto::CURLOPT_DIRLISTONLY);
+  list_only->set_bool_value(true);
+  auto *custom_request = scenario.add_options();
+  custom_request->set_option_id(curl::fuzzer::proto::CURLOPT_CUSTOMREQUEST);
+  custom_request->set_string_value("X-LIST");
+  AddLoginAndPwdReplies(&scenario);
+  auto *control = scenario.mutable_connection();
+  control->add_on_readable(
+      "229 Entering Extended Passive Mode (|||12345|)\r\n");
+  control->add_on_readable("200 type set\r\n");
+  control->add_on_readable("150 custom listing\r\n");
+  control->add_on_readable("226 listed\r\n");
+  scenario.add_subsequent_connections()->set_initial_response(
+      "custom-entry\r\n");
+
+  const FtpRunResult result = RunScenario(scenario, "ftp://ftp.test/");
+  Expect(result.code == CURLE_OK, "custom FTP listing did not complete");
+  Expect(result.body == "custom-entry\n",
+         "custom FTP listing did not receive its passive payload");
+  Expect(result.transcript.find("X-LIST\r\n") != std::string::npos,
+         "CURLOPT_CUSTOMREQUEST did not replace the listing command");
+}
+
+void TestExplicitEmptyCompletionExposesControlEof() {
+  Scenario scenario;
+  AddLoginAndPwdReplies(&scenario);
+  auto *control = scenario.mutable_connection();
+  control->add_on_readable(
+      "229 Entering Extended Passive Mode (|||12345|)\r\n");
+  control->add_on_readable("200 type set\r\n");
+  control->add_on_readable("213 4\r\n");
+  control->add_on_readable("150 opening data\r\n");
+  control->add_on_readable("");
+  scenario.add_subsequent_connections()->set_initial_response("body");
+
+  const FtpRunResult result = RunScenario(scenario, "ftp://ftp.test/file");
+  Expect(result.code != CURLE_OK,
+         "empty FTP completion was replaced by synthetic success");
+  Expect(result.body == "body",
+         "control EOF prevented the passive body from being delivered");
+}
+
+} // namespace
+
+int main() {
+  if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    Fail("curl_global_init failed");
+  }
+  TestEpsvDownloadAndFinalReply();
+  TestEpsvFailureFallsBackToPasv();
+  TestUploadIsDrainedWithoutLosingControlChannel();
+  TestCustomListingCommandReceivesPassiveData();
+  TestExplicitEmptyCompletionExposesControlEof();
+  curl_global_cleanup();
+  return 0;
+}

--- a/tests/target_policy_test.cc
+++ b/tests/target_policy_test.cc
@@ -17,9 +17,11 @@
 namespace {
 
 using curl::fuzzer::proto::Scenario;
+using curl::fuzzer::proto::SCHEME_FTP;
 using curl::fuzzer::proto::SCHEME_HTTP;
 using curl::fuzzer::proto::SCHEME_HTTPS;
 using curl::fuzzer::proto::SCHEME_TELNET;
+using curl::fuzzer::proto::SCHEME_TFTP;
 using curl::fuzzer::proto::SCHEME_UNSPECIFIED;
 using curl::fuzzer::proto::SCHEME_WS;
 using curl::fuzzer::proto::SCHEME_WSS;
@@ -253,6 +255,108 @@ void TestFastTelnetPolicy() {
     Expect(scenario.options(index).option_id() == kRetained[index],
            "fast TELNET policy changed retained option order");
   }
+}
+
+void TestFastFtpPolicy() {
+  Scenario scenario = ScenarioWithBackpressure(SCHEME_HTTP, 4096, 17);
+  scenario.set_host_path("mutated.invalid:9999/a/b/file");
+  scenario.add_request_headers("X-Ignored: ftp");
+  scenario.mutable_mime_post()->add_parts()->set_data("mime");
+  scenario.add_telnet_options("TTYPE=ignored");
+  scenario.mutable_api_plan()->set_duplicate_easy(true);
+  scenario.mutable_upload()->set_data("upload sentinel");
+  scenario.mutable_connection()->add_on_readable("control reply");
+  scenario.mutable_connection()->add_server_frames()->set_payload("frame");
+  for (std::size_t index = 0;
+       index < proto_fuzzer::scenario_limits::kMaxConnections + 2; ++index) {
+    auto *data = scenario.add_subsequent_connections();
+    data->set_initial_response("data-" + std::to_string(index));
+    data->mutable_backpressure()->set_drain_limit(1);
+    data->add_server_frames()->set_payload("ignored frame");
+  }
+
+  auto *rejected = scenario.add_options();
+  rejected->set_option_id(curl::fuzzer::proto::CURLOPT_HTTP_VERSION);
+  auto *create_dirs = scenario.add_options();
+  create_dirs->set_option_id(
+      curl::fuzzer::proto::CURLOPT_FTP_CREATE_MISSING_DIRS);
+  create_dirs->set_uint_value(std::numeric_limits<std::uint64_t>::max());
+  auto *file_method = scenario.add_options();
+  file_method->set_option_id(curl::fuzzer::proto::CURLOPT_FTP_FILEMETHOD);
+  file_method->set_uint_value(99);
+  scenario.add_options()->set_option_id(curl::fuzzer::proto::CURLOPT_UPLOAD);
+
+  ApplyTargetPolicy(&scenario, TargetProfile::kFastFtp);
+
+  Expect(scenario.scheme() == SCHEME_FTP, "fast FTP policy did not force FTP");
+  Expect(scenario.host_path() == "ftp.test/a/b/file",
+         "fast FTP policy did not retain only the URL path");
+  Expect(scenario.request_headers_size() == 0 && !scenario.has_mime_post() &&
+             scenario.telnet_options_size() == 0 && !scenario.has_api_plan(),
+         "fast FTP policy retained another protocol's shape");
+  Expect(scenario.has_upload() && scenario.upload().data() == "upload sentinel",
+         "fast FTP policy removed callback-backed upload data");
+  Expect(scenario.connection().on_readable(0) == "control reply" &&
+             !scenario.connection().has_backpressure() &&
+             scenario.connection().server_frames_size() == 0,
+         "fast FTP policy changed raw control data or retained stream-only "
+         "controls");
+  Expect(static_cast<std::size_t>(scenario.subsequent_connections_size()) ==
+             proto_fuzzer::scenario_limits::kMaxConnections - 1,
+         "fast FTP policy exceeded its passive data-channel budget");
+  Expect(!scenario.subsequent_connections(0).has_backpressure() &&
+             scenario.subsequent_connections(0).server_frames_size() == 0,
+         "fast FTP policy retained ignored data-channel controls");
+  Expect(scenario.options_size() == 3,
+         "fast FTP policy retained a non-FTP option");
+  Expect(scenario.options(0).uint_value() < 3 &&
+             scenario.options(1).uint_value() < 4,
+         "fast FTP policy left small enums outside curl's valid domains");
+}
+
+void TestFastTftpPolicy() {
+  Scenario scenario = ScenarioWithBackpressure(SCHEME_WSS, 4096, 17);
+  scenario.set_host_path("untrusted.invalid:1234/path;mode=netascii?query");
+  scenario.mutable_connection()->add_on_readable("packet one");
+  scenario.mutable_connection()->add_on_readable("");
+  scenario.mutable_connection()->add_server_frames()->set_payload("frame");
+  scenario.add_subsequent_connections()->set_initial_response("stream-only");
+  scenario.add_request_headers("X-Ignored: tftp");
+  scenario.mutable_mime_post()->add_parts()->set_data("mime");
+  scenario.add_telnet_options("TTYPE=ignored");
+  scenario.mutable_api_plan()->set_duplicate_easy(true);
+  scenario.mutable_upload()->set_data("upload sentinel");
+
+  scenario.add_options()->set_option_id(curl::fuzzer::proto::CURLOPT_POST);
+  auto *block_size = scenario.add_options();
+  block_size->set_option_id(curl::fuzzer::proto::CURLOPT_TFTP_BLKSIZE);
+  block_size->set_uint_value(std::numeric_limits<std::uint64_t>::max());
+  scenario.add_options()->set_option_id(
+      curl::fuzzer::proto::CURLOPT_TFTP_NO_OPTIONS);
+
+  ApplyTargetPolicy(&scenario, TargetProfile::kFastTftp);
+
+  Expect(scenario.scheme() == SCHEME_TFTP,
+         "fast TFTP policy did not force TFTP");
+  Expect(scenario.host_path() == "tftp.test/path;mode=netascii?query",
+         "fast TFTP policy did not retain the filename/mode suffix");
+  Expect(scenario.subsequent_connections_size() == 0 &&
+             scenario.request_headers_size() == 0 &&
+             !scenario.has_mime_post() && scenario.telnet_options_size() == 0 &&
+             !scenario.has_api_plan(),
+         "fast TFTP policy retained stream or another protocol's shape");
+  Expect(scenario.has_upload() && scenario.upload().data() == "upload sentinel",
+         "fast TFTP policy removed WRQ upload data");
+  Expect(scenario.connection().on_readable_size() == 2 &&
+             scenario.connection().on_readable(1).empty(),
+         "fast TFTP policy lost a UDP packet boundary");
+  Expect(!scenario.connection().has_backpressure() &&
+             scenario.connection().server_frames_size() == 0,
+         "fast TFTP policy retained stream-only connection controls");
+  Expect(scenario.options_size() == 2,
+         "fast TFTP policy retained a non-TFTP option");
+  Expect(scenario.options(0).uint_value() == 65464,
+         "fast TFTP policy did not clamp block size to curl's upper boundary");
 }
 
 void TestPauseTerminalIsTelnetOnly() {
@@ -641,6 +745,8 @@ void TestProtocolPoliciesDiscardApiPlans() {
       TargetProfile::kFastWebSocket,
       TargetProfile::kFastSecureWebSocket,
       TargetProfile::kFastTelnet,
+      TargetProfile::kFastFtp,
+      TargetProfile::kFastTftp,
       TargetProfile::kTiming,
   };
 
@@ -685,6 +791,10 @@ void TestProfileRunModes() {
          "API profile does not authorize its lifecycle plan");
   Expect(RunModeFor(TargetProfile::kFastHttps) == ScenarioRunMode::kTlsCoverage,
          "fast HTTPS profile does not authorize the real TLS peer");
+  Expect(RunModeFor(TargetProfile::kFastFtp) == ScenarioRunMode::kFtpCoverage,
+         "fast FTP profile does not authorize the two-channel peer");
+  Expect(RunModeFor(TargetProfile::kFastTftp) == ScenarioRunMode::kTftpCoverage,
+         "fast TFTP profile does not authorize the UDP peer");
 
   constexpr TargetProfile kCoverageProfiles[] = {
       TargetProfile::kDeepHttp,
@@ -720,6 +830,8 @@ int main() {
   TestFastWebSocketPolicy();
   TestFastSecureWebSocketPolicy();
   TestFastTelnetPolicy();
+  TestFastFtpPolicy();
+  TestFastTftpPolicy();
   TestPauseTerminalIsTelnetOnly();
   TestNonTelnetPolicySelectsUploadBudgetBeforeBounding();
   TestFastTelnetResponseBudgets();

--- a/tests/test_compare_fuzzers.py
+++ b/tests/test_compare_fuzzers.py
@@ -283,6 +283,15 @@ def test_telnet_lane_is_a_default_fixed_proto_target() -> None:
     assert "curl_fuzzer_proto_telnet" in module.HISTORICAL_PROTO_CORPUS_TARGETS
 
 
+def test_ftp_and_tftp_lanes_keep_legacy_speed_baselines() -> None:
+    module = _load_module()
+
+    assert "curl_fuzzer_ftp" in module.DEFAULT_TARGETS
+    assert "curl_fuzzer_proto_ftp" in module.DEFAULT_TARGETS
+    assert "curl_fuzzer_tftp" in module.DEFAULT_TARGETS
+    assert "curl_fuzzer_proto_tftp" in module.DEFAULT_TARGETS
+
+
 def test_cli_compares_native_corpora_and_source_coverage_for_target_pair(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_ftp_tftp_scenarios.py
+++ b/tests/test_ftp_tftp_scenarios.py
@@ -1,0 +1,113 @@
+"""Reachability checks for correlated FTP and TFTP protocol seeds."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SUPPORTED_OPTIONS = REPO_ROOT / "schemas" / "curl_fuzzer_supported_curlopts.txt"
+SCENARIO_ROOT = REPO_ROOT / "scenarios" / "curl_fuzzer_proto"
+
+
+def _supported_options() -> set[str]:
+    return {
+        line
+        for raw_line in SUPPORTED_OPTIONS.read_text(encoding="utf-8").splitlines()
+        if (line := raw_line.strip()) and not line.startswith("#")
+    }
+
+
+def test_file_transfer_controls_are_reachable_without_active_networking() -> None:
+    """Expose passive/scalar controls while the harness owns all routing."""
+    supported = _supported_options()
+    assert {
+        "CURLOPT_DIRLISTONLY",
+        "CURLOPT_APPEND",
+        "CURLOPT_TRANSFERTEXT",
+        "CURLOPT_FTP_USE_EPSV",
+        "CURLOPT_FTP_CREATE_MISSING_DIRS",
+        "CURLOPT_FTP_ACCOUNT",
+        "CURLOPT_FTP_SKIP_PASV_IP",
+        "CURLOPT_FTP_FILEMETHOD",
+        "CURLOPT_FTP_ALTERNATIVE_TO_USER",
+        "CURLOPT_FTP_USE_PRET",
+        "CURLOPT_WILDCARDMATCH",
+        "CURLOPT_TFTP_BLKSIZE",
+        "CURLOPT_TFTP_NO_OPTIONS",
+    } <= supported
+    assert {
+        "CURLOPT_FTPPORT",
+        "CURLOPT_FTP_USE_EPRT",
+        "CURLOPT_USE_SSL",
+        "CURLOPT_QUOTE",
+        "CURLOPT_PREQUOTE",
+        "CURLOPT_POSTQUOTE",
+    }.isdisjoint(supported)
+
+
+def test_ftp_seeds_retain_control_and_data_correlations() -> None:
+    """Keep command replies paired with passive-channel payloads."""
+    expected_tokens = {
+        "ftp_epsv_retr.textproto": (
+            "229 Entering Extended Passive Mode",
+            "150 opening data connection",
+            'initial_response: "hello world"',
+        ),
+        "ftp_pasv_fallback.textproto": (
+            "500 EPSV unsupported",
+            "227 Entering Passive Mode",
+            'initial_response: "fallback"',
+        ),
+        "ftp_upload_stor.textproto": (
+            "CURLOPT_UPLOAD bool_value: true",
+            'data: "upload-bytes"',
+            "226 stored",
+        ),
+        "ftp_create_directories.textproto": (
+            "CURLOPT_FTP_CREATE_MISSING_DIRS uint_value: 2",
+            "550 missing a",
+            "257 a created",
+        ),
+        "ftp_custom_list.textproto": (
+            'CURLOPT_CUSTOMREQUEST string_value: "X-LIST"',
+            "150 custom listing",
+            'initial_response: "custom-entry\\r\\n"',
+        ),
+        "ftp_completion_eof.textproto": (
+            "150 data",
+            'on_readable: ""',
+            'initial_response: "body"',
+        ),
+    }
+    ftp_root = SCENARIO_ROOT / "ftp"
+    for name, tokens in expected_tokens.items():
+        scenario = (ftp_root / name).read_text(encoding="utf-8")
+        assert all(token in scenario for token in tokens), name
+
+
+def test_tftp_seeds_preserve_datagram_boundaries_and_state_pairs() -> None:
+    """Protect OACK/DATA/ACK sequences mutation is unlikely to rediscover."""
+    expected_tokens = {
+        "tftp_rrq_oack_multiblock.textproto": (
+            "\\000\\006blksize\\0008",
+            "\\000\\003\\000\\001abcdefgh",
+            "\\000\\003\\000\\002ijk",
+        ),
+        "tftp_wrq_oack_exact_block.textproto": (
+            "CURLOPT_INFILESIZE_LARGE uint_value: 8",
+            "\\000\\004\\000\\001",
+            "\\000\\004\\000\\002",
+        ),
+        "tftp_duplicate_data.textproto": (
+            "\\000\\003\\000\\001abcdefgh",
+            "\\000\\003\\000\\002z",
+        ),
+        "tftp_error_not_found.textproto": (
+            "\\000\\005\\000\\001not found\\000",
+        ),
+    }
+    tftp_root = SCENARIO_ROOT / "tftp"
+    for name, tokens in expected_tokens.items():
+        scenario = (tftp_root / name).read_text(encoding="utf-8")
+        assert all(token in scenario for token in tokens), name

--- a/tests/test_fuzzer_entrypoints.py
+++ b/tests/test_fuzzer_entrypoints.py
@@ -10,6 +10,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ENTRYPOINT_PATTERN = re.compile(r'extern\s+"C"\s+int\s+LLVMFuzzerTestOneInput\s*\(')
+CUSTOM_MUTATOR_PATTERN = re.compile(
+    r'extern\s+"C"\s+std::size_t\s+LLVMFuzzerCustomMutator\s*\('
+)
+CUSTOM_CROSSOVER_PATTERN = re.compile(
+    r'extern\s+"C"\s+std::size_t\s+LLVMFuzzerCustomCrossOver\s*\('
+)
 LEGACY_TARGET_PATTERN = re.compile(
     r"^\s*curl_add_fuzzer\(\s*([a-z0-9_]+)", re.MULTILINE
 )
@@ -17,6 +23,19 @@ PROTO_TARGET_PATTERN = re.compile(
     r"^\s*curl_add_proto_fuzzer\(\s*([a-z0-9_]+)", re.MULTILINE
 )
 STANDALONE_TARGETS = {"fuzz_bufq", "fuzz_doh", "fuzz_url"}
+PROTO_TARGET_PROFILES = {
+    "curl_fuzzer_proto": "kCompatibility",
+    "curl_fuzzer_proto_http": "kFastHttp",
+    "curl_fuzzer_proto_http_deep": "kDeepHttp",
+    "curl_fuzzer_proto_https": "kFastHttps",
+    "curl_fuzzer_proto_ws": "kFastWebSocket",
+    "curl_fuzzer_proto_wss": "kFastSecureWebSocket",
+    "curl_fuzzer_proto_telnet": "kFastTelnet",
+    "curl_fuzzer_proto_ftp": "kFastFtp",
+    "curl_fuzzer_proto_tftp": "kFastTftp",
+    "curl_fuzzer_proto_api": "kApi",
+    "curl_fuzzer_proto_timing": "kTiming",
+}
 
 
 def _packaged_targets() -> set[str]:
@@ -73,3 +92,22 @@ def test_cmake_builds_every_packaged_entrypoint() -> None:
 
     assert cmake_targets == _packaged_targets()
     assert cmake.count("fuzzer_entrypoints/${_name}.cc") == 2
+
+
+def test_proto_entrypoints_bind_profiles_in_source() -> None:
+    """Keep target behaviour visible in C++, including mutation callbacks."""
+    for target, profile in PROTO_TARGET_PROFILES.items():
+        source = REPO_ROOT / "fuzzer_entrypoints" / f"{target}.cc"
+        contents = source.read_text(encoding="utf-8")
+
+        assert contents.count(f"TargetProfile::{profile}") == 1
+        assert len(ENTRYPOINT_PATTERN.findall(contents)) == 1
+        assert len(CUSTOM_MUTATOR_PATTERN.findall(contents)) == 1
+        assert len(CUSTOM_CROSSOVER_PATTERN.findall(contents)) == 1
+
+    shared_main = (REPO_ROOT / "proto_fuzzer" / "fuzzer_main.cc").read_text(
+        encoding="utf-8"
+    )
+    cmake = (REPO_ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+    assert "PROTO_FUZZER_TARGET_" not in shared_main
+    assert "PROTO_FUZZER_TARGET_" not in cmake

--- a/tests/tftp_mock_server_test.cc
+++ b/tests/tftp_mock_server_test.cc
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include <curl/curl.h>
+
+#include <cstdlib>
+#include <initializer_list>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "curl_fuzzer.pb.h"
+#include "proto_fuzzer/option_apply.h"
+#include "proto_fuzzer/request_data.h"
+#include "proto_fuzzer/tftp_mock_server.h"
+
+namespace {
+
+using curl::fuzzer::proto::Scenario;
+
+struct CurlEasyDeleter {
+  void operator()(CURL *easy) const { curl_easy_cleanup(easy); }
+};
+
+struct CurlSlistDeleter {
+  void operator()(curl_slist *list) const { curl_slist_free_all(list); }
+};
+
+using CurlEasyPtr = std::unique_ptr<CURL, CurlEasyDeleter>;
+using CurlSlistPtr = std::unique_ptr<curl_slist, CurlSlistDeleter>;
+
+void Fail(const char *message) {
+  std::cerr << message << '\n';
+  std::exit(1);
+}
+
+void Expect(bool condition, const char *message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+std::string Packet(std::uint16_t opcode, std::uint16_t value,
+                   const std::string &payload = {}) {
+  std::string packet;
+  packet.push_back(static_cast<char>(opcode >> 8));
+  packet.push_back(static_cast<char>(opcode));
+  packet.push_back(static_cast<char>(value >> 8));
+  packet.push_back(static_cast<char>(value));
+  packet += payload;
+  return packet;
+}
+
+std::string OptionAck(std::initializer_list<const char *> values) {
+  std::string packet("\0\x06", 2);
+  for (const char *value : values) {
+    packet += value;
+    packet.push_back('\0');
+  }
+  return packet;
+}
+
+size_t CollectResponse(char *contents, size_t size, size_t nmemb,
+                       void *userdata) {
+  const size_t bytes = size * nmemb;
+  static_cast<std::string *>(userdata)->append(contents, bytes);
+  return bytes;
+}
+
+struct TftpRunResult {
+  CURLcode code = CURLE_FAILED_INIT;
+  std::string body;
+  std::vector<proto_fuzzer::TftpReceivedDatagram> received;
+  std::uint16_t request_port = 0;
+  std::uint16_t transfer_port = 0;
+};
+
+TftpRunResult RunScenario(const Scenario &scenario) {
+  TftpRunResult result;
+  CurlEasyPtr easy(curl_easy_init());
+  Expect(easy != nullptr, "curl_easy_init failed");
+  CurlSlistPtr connect_to(proto_fuzzer::ApplyBaselineOptions(
+      easy.get(), curl::fuzzer::proto::SCHEME_TFTP));
+  Expect(connect_to != nullptr,
+         "TFTP baseline did not create CONNECT_TO state");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_URL, "tftp://tftp.test/file") ==
+             CURLE_OK,
+         "TFTP URL setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_WRITEFUNCTION,
+                          &CollectResponse) == CURLE_OK,
+         "TFTP write callback setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_WRITEDATA, &result.body) ==
+             CURLE_OK,
+         "TFTP write data setup failed");
+  (void)proto_fuzzer::ApplyScenarioOptions(easy.get(), scenario);
+
+  proto_fuzzer::TftpMockServer server;
+  server.Install(easy.get());
+  {
+    proto_fuzzer::ScenarioRequestData request_data(easy.get(), scenario);
+    result.code = server.DriveScenario(easy.get(), scenario);
+  }
+  result.received = server.received_datagrams();
+  result.request_port = server.request_port();
+  result.transfer_port = server.transfer_port();
+
+  // Pointer-valued baseline options must outlive easy cleanup.
+  easy.reset();
+  connect_to.reset();
+  return result;
+}
+
+void TestOackDownloadUsesTransferId() {
+  Scenario scenario;
+  auto *blksize = scenario.add_options();
+  blksize->set_option_id(curl::fuzzer::proto::CURLOPT_TFTP_BLKSIZE);
+  blksize->set_uint_value(8);
+  auto *connection = scenario.mutable_connection();
+  connection->set_initial_response(OptionAck({"blksize", "8"}));
+  connection->add_on_readable(Packet(3, 1, "abcdefgh"));
+  connection->add_on_readable(Packet(3, 2, "ijk"));
+
+  const TftpRunResult result = RunScenario(scenario);
+  Expect(result.code == CURLE_OK, "OACK TFTP download did not complete");
+  Expect(result.body == "abcdefghijk",
+         "OACK TFTP download produced the wrong body");
+  Expect(result.request_port != 0 && result.transfer_port != 0 &&
+             result.request_port != result.transfer_port,
+         "TFTP request and transfer endpoints did not use distinct IDs");
+  Expect(result.received.size() >= 3,
+         "TFTP peer did not capture RRQ and acknowledgements");
+  Expect(result.received[0].received_on ==
+             proto_fuzzer::TftpSocketRole::kRequest,
+         "initial RRQ did not reach the request endpoint");
+  Expect(result.received[1].received_on ==
+             proto_fuzzer::TftpSocketRole::kTransfer,
+         "ACK0 did not follow the response transfer ID");
+  Expect(result.received[1].bytes == Packet(4, 0),
+         "curl did not acknowledge the OACK with ACK0");
+  Expect(result.received[2].bytes == Packet(4, 1),
+         "curl did not acknowledge DATA1");
+}
+
+void TestNoOptionsRequestAndErrorMapping() {
+  Scenario request;
+  auto *no_options = request.add_options();
+  no_options->set_option_id(curl::fuzzer::proto::CURLOPT_TFTP_NO_OPTIONS);
+  no_options->set_bool_value(true);
+  request.mutable_connection()->set_initial_response(Packet(3, 1, "ok"));
+
+  const TftpRunResult success = RunScenario(request);
+  Expect(success.code == CURLE_OK, "no-options TFTP download did not complete");
+  Expect(!success.received.empty(), "no-options TFTP peer did not capture RRQ");
+  Expect(success.received[0].bytes.find("blksize") == std::string::npos,
+         "CURLOPT_TFTP_NO_OPTIONS still emitted blksize");
+  Expect(success.received[0].bytes.find("tsize") == std::string::npos,
+         "CURLOPT_TFTP_NO_OPTIONS still emitted tsize");
+
+  Scenario error;
+  error.mutable_connection()->set_initial_response(
+      Packet(5, 1, std::string("missing\0", 8)));
+  const TftpRunResult missing = RunScenario(error);
+  Expect(missing.code == CURLE_TFTP_NOTFOUND,
+         "TFTP ERROR 1 did not map to CURLE_TFTP_NOTFOUND");
+}
+
+void TestExactBlockUploadSendsTerminalPacket() {
+  Scenario scenario;
+  auto *upload = scenario.add_options();
+  upload->set_option_id(curl::fuzzer::proto::CURLOPT_UPLOAD);
+  upload->set_bool_value(true);
+  auto *size = scenario.add_options();
+  size->set_option_id(curl::fuzzer::proto::CURLOPT_INFILESIZE_LARGE);
+  size->set_uint_value(8);
+  auto *blksize = scenario.add_options();
+  blksize->set_option_id(curl::fuzzer::proto::CURLOPT_TFTP_BLKSIZE);
+  blksize->set_uint_value(8);
+  scenario.mutable_upload()->set_data("12345678");
+  scenario.mutable_connection()->set_initial_response(
+      OptionAck({"blksize", "8", "tsize", "8"}));
+  scenario.mutable_connection()->add_on_readable(Packet(4, 1));
+  scenario.mutable_connection()->add_on_readable(Packet(4, 2));
+
+  const TftpRunResult result = RunScenario(scenario);
+  Expect(result.code == CURLE_OK, "exact-block TFTP upload did not complete");
+  Expect(result.received.size() >= 3,
+         "TFTP peer did not capture WRQ and both DATA packets");
+  Expect(result.received[1].bytes == Packet(3, 1, "12345678"),
+         "TFTP DATA1 did not contain the upload body");
+  Expect(result.received[2].bytes == Packet(3, 2),
+         "TFTP exact-block upload omitted terminal DATA2");
+}
+
+} // namespace
+
+int main() {
+  if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    Fail("curl_global_init failed");
+  }
+  TestOackDownloadUsesTransferId();
+  TestNoOptionsRequestAndErrorMapping();
+  TestExactBlockUploadSendsTerminalPacket();
+  curl_global_cleanup();
+  return 0;
+}


### PR DESCRIPTION
Add profile-specific structured fuzzers for FTP and TFTP with bounded in-process peers, protocol option policies, and correlated seed corpora.

Model FTP control and passive-data connections, and preserve TFTP UDP datagram boundaries and transfer-ID migration without external networking or wall-clock waits.

Pass TargetProfile explicitly from each entrypoint into shared execution, mutation, and crossover code instead of selecting behaviour through CMake definitions.

Wire both targets into OSS-Fuzz packaging, corpus handling, benchmarking, and focused integration tests.