### PR TITLE
proto: keep CONNECT_ONLY out of the API easy-perform drive

### DIFF
--- a/proto_fuzzer/mock_server.cc
+++ b/proto_fuzzer/mock_server.cc
@@ -360,10 +360,10 @@ curl_socket_t MockServer::HandleOpenSocket(curlsocktype purpose, struct curl_soc
 /// Preload all bounded response bytes from inside OPENSOCKETFUNCTION, where
 /// the mock still owns both socketpair ends. The total serialized fuzz input
 /// is capped by libFuzzer's max_len. If a non-blocking preload fills the local
-/// socket, curl observes only the successfully queued prefix and the short
-/// timeout below bounds the incomplete response. Reassert that timeout after
-/// scenario setopts so a mutated blocking option cannot turn this synchronous
-/// coverage path into a hung worker.
+/// socket, curl observes only the successfully queued prefix and the timeouts
+/// below bound the incomplete response. Unlike every other drive loop, this one
+/// has no iteration budget of its own, so it reasserts those timeouts after
+/// scenario setopts and clears the one option that can disable them.
 /// @param easy Configured easy handle whose open-socket callback targets this
 ///        mock.
 /// @param scenario Bounded response script to preload before performing.
@@ -372,6 +372,14 @@ void MockServer::DriveEasyScenario(CURL* easy, const curl::fuzzer::proto::Scenar
   preload_all_chunks_ = true;
   (void)curl_easy_setopt(easy, CURLOPT_TIMEOUT_MS, 50L);
   (void)curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS, 50L);
+  // CONNECT_ONLY makes curl's timeleft check report "no limit" for the whole
+  // post-connect phase, so the timeouts above stop being enforced; value 2
+  // additionally skips the connect-only shortcut and runs a complete transfer.
+  // Clearing it is not a coverage loss: the multi-driven WebSocket lanes still
+  // exercise CONNECT_ONLY under their own iteration budget. Zero rather than
+  // one because CONNECT_ONLY=1 also disables the timeout and stays bounded only
+  // through a curl-internal shortcut this harness should not depend on.
+  (void)curl_easy_setopt(easy, CURLOPT_CONNECT_ONLY, 0L);
   (void)curl_easy_perform(easy);
   preload_all_chunks_ = false;
 }

--- a/tests/mock_server_test.cc
+++ b/tests/mock_server_test.cc
@@ -9,6 +9,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -820,6 +821,67 @@ void TestEasyPerformPreloadsIncrementalResponse() {
   curl_slist_free_all(connect_to);
 }
 
+/// CURLOPT_CONNECT_ONLY disables curl's own transfer timeout, and value 2 keeps
+/// a full request running. Combined with an upload that provokes
+/// Expect: 100-continue, that left curl_easy_perform waiting out the entire
+/// expect timeout with nothing to bound it. Assert wall-clock as well as
+/// content: pre-fix curl does deliver the response, just 65 seconds later.
+void TestEasyPerformBoundsConnectOnlyUpload() {
+  Scenario scenario;
+  scenario.set_scheme(curl::fuzzer::proto::SCHEME_HTTP);
+  scenario.set_host_path("api.test/easy");
+  scenario.mutable_connection()->set_initial_response(
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n");
+  scenario.mutable_connection()->add_on_readable("ok");
+  scenario.mutable_upload()->set_data("body");
+
+  auto *upload = scenario.add_options();
+  upload->set_option_id(curl::fuzzer::proto::CURLOPT_UPLOAD);
+  upload->set_bool_value(true);
+  auto *expect_timeout = scenario.add_options();
+  expect_timeout->set_option_id(
+      curl::fuzzer::proto::CURLOPT_EXPECT_100_TIMEOUT_MS);
+  expect_timeout->set_uint_value(65535);
+  auto *connect_only = scenario.add_options();
+  connect_only->set_option_id(curl::fuzzer::proto::CURLOPT_CONNECT_ONLY);
+  connect_only->set_uint_value(2);
+
+  CURL *easy = curl_easy_init();
+  Expect(easy != nullptr,
+         "connect-only upload test could not allocate an easy handle");
+  struct curl_slist *connect_to = proto_fuzzer::ApplyBaselineOptions(
+      easy, curl::fuzzer::proto::SCHEME_HTTP);
+  curl_easy_setopt(easy, CURLOPT_URL, "http://api.test/easy");
+
+  std::string response;
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, &CollectResponse);
+  curl_easy_setopt(easy, CURLOPT_WRITEDATA, &response);
+
+  TestMockServer server;
+  server.Install(easy);
+  // Route through the production option path so the CONNECT_ONLY decode is
+  // covered too, not just the resulting setopt.
+  (void)proto_fuzzer::ApplyScenarioOptions(easy, scenario);
+
+  const auto start = std::chrono::steady_clock::now();
+  {
+    // Without this owner, NeedsUploadCallbacks is unsatisfied and curl reads
+    // the request body from stdin.
+    proto_fuzzer::ScenarioRequestData request_data(easy, scenario);
+    server.DriveEasyScenario(easy, scenario);
+  }
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start);
+
+  Expect(response == "ok",
+         "connect-only upload did not complete the preloaded response");
+  Expect(elapsed < std::chrono::milliseconds(2000),
+         "CONNECT_ONLY disabled the easy-perform drive's transfer timeout");
+
+  curl_easy_cleanup(easy);
+  curl_slist_free_all(connect_to);
+}
+
 void TestTelnetPreloadsChunksAndNeverReadsStdin() {
   Scenario scenario;
   scenario.set_scheme(curl::fuzzer::proto::SCHEME_TELNET);
@@ -965,6 +1027,7 @@ int main() {
 #endif
   TestApiLifecycleCompletesSocketActionTransfer();
   TestEasyPerformPreloadsIncrementalResponse();
+  TestEasyPerformBoundsConnectOnlyUpload();
   TestTelnetPreloadsChunksAndNeverReadsStdin();
   TestTelnetMaximumAmplificationCannotBlock();
   return 0;


### PR DESCRIPTION
CURLOPT_CONNECT_ONLY makes libcurl's timeleft check report "no limit" for the whole post-connect phase, and value 2 additionally skips the connect-only shortcut so a complete transfer still runs. Together those disable the CURLOPT_TIMEOUT_MS that DriveEasyScenario relies on: unlike every other drive loop, it has no iteration budget of its own.

An OSS-Fuzz testcase combined CONNECT_ONLY=2 with an upload that provokes Expect: 100-continue, leaving curl_easy_perform parked in AWAITING_CONTINUE for the mutated 65535ms expect timeout. Clear the option before performing; the multi-driven WebSocket lanes still cover CONNECT_ONLY under their own budget. Zero rather than one, because CONNECT_ONLY=1 also voids the timeout and stays bounded only through a curl-internal shortcut this harness should not depend on.