### PR TITLE
proto_fuzzer: add selectable TLS certificate chains

### DIFF
--- a/proto_fuzzer/scenario_runner.cc
+++ b/proto_fuzzer/scenario_runner.cc
@@ -121,7 +121,7 @@ std::unique_ptr<MockServerBase> MakeMockServerForScenario(const curl::fuzzer::pr
     case curl::fuzzer::proto::SCHEME_HTTPS:
 #if defined(PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
       if (mode == ScenarioRunMode::kTlsCoverage) {
-        return std::make_unique<TlsMockServer>();
+        return std::make_unique<TlsMockServer>(scenario.tls_certificate_chain());
       }
 #else
       (void)mode;

--- a/proto_fuzzer/target_policy.cc
+++ b/proto_fuzzer/target_policy.cc
@@ -831,6 +831,13 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     return;
   }
 
+  // Only the dedicated HTTPS peer consumes a certificate-chain selector.
+  // Remove it before protocol-specific early returns so other fixed targets
+  // do not spend mutations on inert TLS server state.
+  if (profile != TargetProfile::kFastHttps) {
+    scenario->clear_tls_certificate_chain();
+  }
+
   if (profile == TargetProfile::kFastTelnet) {
     // Set the scheme before general bounds so the TELNET-specific upload and
     // PAUSE budgets are selected rather than event-driven compatibility ones.
@@ -975,6 +982,14 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     case TargetProfile::kFastHttps:
       ClearAllBackpressure(scenario);
       CanonicalizeTlsAuthority(scenario);
+      switch (scenario->tls_certificate_chain()) {
+        case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC:
+        case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES:
+          break;
+        default:
+          scenario->clear_tls_certificate_chain();
+          break;
+      }
       return;
 
     case TargetProfile::kH2Proxy:

--- a/proto_fuzzer/tls_mock_server.cc
+++ b/proto_fuzzer/tls_mock_server.cc
@@ -72,7 +72,7 @@ int SelectAlpn(SSL* /*ssl*/, const unsigned char** selected, unsigned char* sele
 /// one fuzz input from affecting the next.
 class TlsServerContext {
  public:
-  explicit TlsServerContext(TlsApplicationProtocol protocol)
+  TlsServerContext(TlsApplicationProtocol protocol, curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain)
       : context_(nullptr),
         protocol_(protocol),
         negotiated_tls_version_(0),
@@ -86,7 +86,7 @@ class TlsServerContext {
 #endif
     OpenSslErrorQueueGuard error_guard;
     context_ = SSL_CTX_new(TLS_server_method());
-    if (context_ == nullptr || !LoadCredentials() || !LoadEchConfig()) {
+    if (context_ == nullptr || !LoadCredentials(certificate_chain) || !LoadEchConfig()) {
       SSL_CTX_free(context_);
       context_ = nullptr;
       return;
@@ -164,8 +164,28 @@ class TlsServerContext {
   const std::string& ech_outer_name() const { return ech_outer_name_; }
 
  private:
+  /// Append one profile-selected peer certificate without requiring it to
+  /// authenticate the TLS handshake. OpenSSL transfers ownership on success;
+  /// failure leaves cleanup with the caller.
+  bool AddExtraChainCertificate(const char* certificate_pem) {
+    BIO* certificate_bio = BIO_new_mem_buf(certificate_pem, -1);
+    if (certificate_bio == nullptr) {
+      return false;
+    }
+    X509* certificate = PEM_read_bio_X509(certificate_bio, nullptr, nullptr, nullptr);
+    BIO_free(certificate_bio);
+    if (certificate == nullptr) {
+      return false;
+    }
+    if (SSL_CTX_add_extra_chain_cert(context_, certificate) != 1) {
+      X509_free(certificate);
+      return false;
+    }
+    return true;
+  }
+
   /// Parse the checked-in test-only PEM values entirely in memory.
-  bool LoadCredentials() {
+  bool LoadCredentials(curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain) {
     BIO* certificate_bio = BIO_new_mem_buf(tls_test_credentials::kCertificatePem, -1);
     BIO* key_bio = BIO_new_mem_buf(tls_test_credentials::kPrivateKeyPem, -1);
     if (certificate_bio == nullptr || key_bio == nullptr) {
@@ -188,7 +208,19 @@ class TlsServerContext {
                         SSL_CTX_use_PrivateKey(context_, key) == 1 && SSL_CTX_check_private_key(context_) == 1;
     X509_free(certificate);
     EVP_PKEY_free(key);
-    return loaded;
+    if (!loaded) {
+      return false;
+    }
+
+    switch (certificate_chain) {
+      case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES:
+        return AddExtraChainCertificate(tls_test_credentials::kRsaCertificatePem) &&
+               AddExtraChainCertificate(tls_test_credentials::kDsaCertificatePem) &&
+               AddExtraChainCertificate(tls_test_credentials::kDhCertificatePem);
+      case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC:
+      default:
+        return true;
+    }
   }
 
   /// Load a fixed test-only ECH private key and matching public config. This
@@ -433,11 +465,16 @@ class TlsMockConnection final : public MockConnection {
 }  // namespace
 
 /// Build one reusable in-process server context per fuzz iteration.
-TlsMockServer::TlsMockServer() : TlsMockServer(TlsApplicationProtocol::kHttp11) {}
+TlsMockServer::TlsMockServer() : TlsMockServer(curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC) {}
+
+/// Select one bounded certificate chain while retaining HTTP/1.1 ALPN.
+TlsMockServer::TlsMockServer(curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain)
+    : TlsMockServer(TlsApplicationProtocol::kHttp11, certificate_chain) {}
 
 /// Construct the shared TLS transport with one fixed ALPN outcome.
-TlsMockServer::TlsMockServer(TlsApplicationProtocol protocol)
-    : context_(std::make_unique<TlsServerContext>(protocol)), saw_live_tls_session_(false) {}
+TlsMockServer::TlsMockServer(TlsApplicationProtocol protocol,
+                             curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain)
+    : context_(std::make_unique<TlsServerContext>(protocol, certificate_chain)), saw_live_tls_session_(false) {}
 
 /// Release SSL objects before their owning server context. OpenSSL reference
 /// counting makes the reverse order legal, but making the ownership order

--- a/proto_fuzzer/tls_mock_server.h
+++ b/proto_fuzzer/tls_mock_server.h
@@ -38,6 +38,10 @@ class TlsServerContext;
 class TlsMockServer : public MockServer {
  public:
   TlsMockServer();
+
+  /// Construct an HTTP/1.1 TLS peer with a bounded certificate-chain profile.
+  /// @param certificate_chain Peer certificate chain presented to curl.
+  explicit TlsMockServer(curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain);
   ~TlsMockServer() override;
 
   TlsMockServer(const TlsMockServer&) = delete;
@@ -81,7 +85,10 @@ class TlsMockServer : public MockServer {
  protected:
   /// Construct a TLS transport for a protocol-specific derived peer.
   /// @param protocol Fixed application protocol the server must negotiate.
-  explicit TlsMockServer(TlsApplicationProtocol protocol);
+  /// @param certificate_chain Peer certificate chain presented to curl.
+  explicit TlsMockServer(TlsApplicationProtocol protocol,
+                         curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain =
+                             curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC);
 
   /// Wrap one socketpair server endpoint in an OpenSSL acceptor.
   /// @return a failed connection when context setup was unavailable.

--- a/proto_fuzzer/tls_test_credentials.h
+++ b/proto_fuzzer/tls_test_credentials.h
@@ -48,6 +48,77 @@ VSpO3203VEY2vHBr/ge5V631IKRcpepoOOPPoT2ixTVTm+wt/kxX8p/G
 -----END PRIVATE KEY-----
 )PEM";
 
+/// Auxiliary certificates signed by kPrivateKeyPem. The all-key-types chain
+/// sends them after the ordinary EC leaf: they are peer-controlled untrusted
+/// entries rather than issuers, so OpenSSL can verify the directly trusted
+/// leaf while curl still formats every public key in SSL_get_peer_cert_chain.
+/// Their private keys are intentionally omitted because they never
+/// authenticate the handshake.
+inline constexpr char kRsaCertificatePem[] = R"PEM(-----BEGIN CERTIFICATE-----
+MIIB3DCCAYECAjABMAoGCCqGSM49BAMCMBMxETAPBgNVBAMTCHRscy50ZXN0MCAX
+DTI2MDkwMzE0MjE0OVoYDzIxMjYwODEwMTQyMTQ5WjASMRAwDgYDVQQDDAdyc2Eu
+YXV4MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Ww/8s0nqQ72eJyv
+Ogbi8JvbXCvl2sOutCDNAP0xTGCCUAlZDOmK1M+LBP8tn6E5Ea6i52sYhXc6Dhx2
+cXY11LQ3IrVzORPQ4ONsxgsqmUIcDG4Kujac0qev3SpmfI+eRoRIj7A62yevhvkp
+/iUfVj5K5jk5sQtOCezY2OYiNqLZjVdBPDJwJjX+wCe0TCj/uN65hyLarNSbHRxw
+jUfhjUpK52KiP/tigyEcftvqM+WqZi74yo59OME7C+Nz9CC3irQD/LnaS66Z6Gxv
+QjoiexgrXLRQeu06SALsJy2vCZQYpvfGG0w8TBDULtOLecj9a1q+nlJZEUvU5zH5
+lvFHbwIDAQABMAoGCCqGSM49BAMCA0kAMEYCIQDZv+GxAR9JNuttTIxE/Z/0lJRI
+Pri54HdZ4lLEiiGZ1AIhAK8mgr7CWGpPF1Wi2R4qumDi4awk0+MpK5JOudetQ2R5
+-----END CERTIFICATE-----
+)PEM";
+
+/// Extension-free X.509 v1 DSA certificate with a deliberately negative
+/// serial. Besides DSA parameter formatting, it covers certinfo's negative
+/// serial and no-extension paths.
+inline constexpr char kDsaCertificatePem[] = R"PEM(-----BEGIN CERTIFICATE-----
+MIID+jCCA6ACAf8wCgYIKoZIzj0EAwIwEzERMA8GA1UEAxMIdGxzLnRlc3QwIBcN
+MjYwOTAzMTQyMjUwWhgPMjEyNjA4MTAxNDIyNTBaMBIxEDAOBgNVBAMMB2RzYS5h
+dXgwggNCMIICNQYHKoZIzjgEATCCAigCggEBAMxwZWGyiSVNbJOKMwiPceUhxBxX
+Vz7YIbfQnqg2SFn3X/BXJ9FCbrnPyylyjMRe5ntgZq5DkiPK8x2rTr22G6Gs91cv
+6iOBPIuO5srSTc/ZPW4eUeMDlmSVpnvh6mWD2AnNilBOcfgChdjQZNl1vKmJPB0T
+J8O9jNyMguJldUFqME7gMUUxZdTLwEN6wFgnB6jw7LrY4zecRvTcXozAKoTYLbts
+7btXSQGzREZLIsyF9WWHklylHl21TV2UdXyeu8AXz7HyvEvUkzA0y6qsMMLNqbVR
+xFfScHQ8lLpYkkZNfNX7tEqYRMAdzRCXJw6sSMt8CYLdbB+kfIoB5dfygEkCHQDH
+JVDypQC4FLz76FR9V+65BKAsh+qqkyTeC/d1AoIBAEC9jvlks7MjV3ju8CNr+AOn
+HeecK3jCrRy2qZz3ylGUa76ZJDzlOIvTE79EjFXMnKKhRrVS8Y6l3y5oRxfa4juc
+dve1agSOI6N9En7x3alE1miNsle+oVL5Agth3OgBifyoMjOofyBk5Jl6xUVOHLwK
+Xp78KyvZEhh3CVOlmdI5UAFCYbD7YjPNZ92jZrH3u09ue/mLdPyDpxGWSlcazsSD
+IGdGZIv9gcR6Qou+zZBJkZBRf+Pu70sJAJuyzRFlddmilzg3AjJ5t5cstsz1LgD4
+vcat41HHp0M9n70DfhSZ4e7W66RJQ0Bsa9suBgVSaIQlYFq6vDSSXK2Al/K8sycD
+ggEFAAKCAQBB+fqotHwXpzyLcZI1ay7YZ0NLY+eD+thfMLCxI5BVHsrP2p0khpKx
+DJvr9HrBCGgrtpFRSmWazZP0O/Q9higv8wGZKn/asIjqqufGZ7ZZ7u0qwNJTAGc3
+GARbNq/Y+UG0CmYStBKx8NNxg29Fkpk9KQkJkkQpslZwqZ30TSzx4xuzF5AGBHY6
+ZGQEijSqsRX7bJnUG2+5qIl+cWJWVb+ceNeIJEGjeSVJFl/t09wTLf9b0uPQKVr/
+lopxOZ8n30iM0zcDb/3+fmGoZZgi376GINlm5Vlsq158aT2wOC9e1auUohhcScxg
+1av12vUzI8MfOS8K52ebSFFDuv1PLlu5MAoGCCqGSM49BAMCA0gAMEUCIQCg72PS
+xpa/xm8prESb2ai1TRPEOdp0ZFF88TuhSGyyHwIgBPE76ZktynQhPthr3oEu4doz
+/VfEwnI57qaOvvRaL0g=
+-----END CERTIFICATE-----
+)PEM";
+
+/// Finite-field PKCS#3 DH certificate. Its dhKeyAgreement SubjectPublicKeyInfo
+/// maps to EVP_PKEY_DH; a DHX certificate would miss curl's dedicated branch.
+inline constexpr char kDhCertificatePem[] = R"PEM(-----BEGIN CERTIFICATE-----
+MIIC3TCCAoMCAjADMAoGCCqGSM49BAMCMBMxETAPBgNVBAMTCHRscy50ZXN0MCAX
+DTI2MDkwMzE0MjE0OVoYDzIxMjYwODEwMTQyMTQ5WjARMQ8wDQYDVQQDDAZkaC5h
+dXgwggIlMIIBFwYJKoZIhvcNAQMBMIIBCAKCAQEA//////////+t+FRYortKmq/c
+ViAnPTzx2LnFg84tNpWp4TZBFGQz+8yTnc4kmz75fS/jY2MMddj2gbICrsRhetPf
+HtXV/WVhJDP1H18GbtCFY2VVPe0a87VXE15/V8k1mE8McODmi3fipona8+/och3x
+WKE2rec1MKzKT0g6eXq8CrGCsyT7YdEIqUuyyOP7uWrat2DX9GgdT0Kj3jlN9K5W
+7edjcrsZCwenyO4KbXCeAvzhzffi7MA0BM0oNC9hkXL+nOmFg/+OTxIy7vKBg8P+
+OxtMb61zO7X8vC7CIAXFjvGDfRaDssbzSibBsu/6iGtCOGEoXJf//////////wIB
+AgOCAQYAAoIBAQCnkXCngCfUjptFONM31hKrPugv8wWDtnLEUP0DWldFWh5sI1HN
+dtBnao8hTIjSLBCep8j6puMfjdMhNRv/jqutYEUKF8cUhNbAXuSPyyzloC1v6RfC
+bRvyqH9km1ymTV5xg7TTBZdHIQ1MeecbiE8PctzXgEKaRIgTou3avwTmAiJxPXj2
+3Zqw2LYxUCXM1S46FhC0zo0kSDtirGYjixNg8euOnJ/4aQHIxLHjbth2PWO1RgGJ
+UAplUBWk9jZinDF1JdK5y5Icrc6Z0ah3K9l66xGM7gAwgqbpQxdceHHYM5DlFWVr
+2pJgcm8Ld93nXNuGPpvRb0YUgRQuJL9slrp9MAoGCCqGSM49BAMCA0gAMEUCIAYb
+DdtuyE3z5UvUm+ic9PSLVgDeGSiL5uzgqRATHboOAiEAw1oL2zLcq6cRyTGtfl9j
+av8pRT4U2I6ZW71jktZp754=
+-----END CERTIFICATE-----
+)PEM";
+
 /// Stable RFC 9849 ECHConfigList advertised to curl by the successful ECH
 /// seed. Its public name is public.test; curl keeps tls.test in the encrypted
 /// inner ClientHello and uses the ordinary certificate above to authenticate

--- a/scenarios/curl_fuzzer_proto/https/https_certinfo_all_key_types.textproto
+++ b/scenarios/curl_fuzzer_proto/https/https_certinfo_all_key_types.textproto
@@ -1,0 +1,12 @@
+# The alternate TLS peer keeps its verified EC identity but sends auxiliary
+# RSA, DSA, and finite-field DH certificates. CERTINFO makes curl walk every
+# peer-supplied entry and format each public-key family in ossl_certchain.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/certinfo-all-key-types"
+tls_certificate_chain: TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES
+options { option_id: CURLOPT_SSL_VERIFYPEER bool_value: true }
+options { option_id: CURLOPT_SSL_VERIFYHOST uint_value: 2 }
+options { option_id: CURLOPT_CERTINFO bool_value: true }
+connection {
+  initial_response: "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\nall-keys"
+}

--- a/schemas/curl_fuzzer.proto
+++ b/schemas/curl_fuzzer.proto
@@ -73,6 +73,19 @@ message Scenario {
   // in the protocol targets. curl_fuzzer_proto_multi retains this plan and
   // applies the same request/response shape to a small set of easy handles.
   MultiPlan multi_plan = 11;
+  // Select the fixed certificate chain served by the dedicated HTTPS peer.
+  // Keeping this a closed profile rather than fuzzing PEM bytes makes every
+  // choice a parseable TLS handshake while still varying the X509 public-key
+  // types consumed by curl. Other fixed protocol lanes discard this field.
+  TlsCertificateChainProfile tls_certificate_chain = 12;
+}
+
+// Test-only certificate bundles available to the in-process TLS server. Zero
+// is the historical single-certificate setup so existing binary corpus inputs
+// preserve both their wire representation and negotiated server identity.
+enum TlsCertificateChainProfile {
+  TLS_CERTIFICATE_CHAIN_DEFAULT_EC = 0;
+  TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES = 1;
 }
 
 // A bounded plan for public libcurl APIs that are adjacent to, rather than

--- a/tests/mock_server_test.cc
+++ b/tests/mock_server_test.cc
@@ -332,6 +332,7 @@ struct TlsTransferResult {
   std::string response;
   long verify_result = -1;
   int certificate_count = 0;
+  std::vector<std::string> certificate_info;
   bool saw_live_tls_session = false;
   int negotiated_version = 0;
   std::size_t handshake_count = 0;
@@ -522,7 +523,7 @@ TlsTransferResult DriveTlsScenario(const Scenario &scenario) {
   const std::string url = "https://" + scenario.host_path();
   curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
 
-  proto_fuzzer::TlsMockServer server;
+  proto_fuzzer::TlsMockServer server(scenario.tls_certificate_chain());
   server.Install(easy);
   for (const auto &option : scenario.options()) {
     Expect(proto_fuzzer::ApplySetOption(easy, option) == CURLE_OK,
@@ -539,6 +540,17 @@ TlsTransferResult DriveTlsScenario(const Scenario &scenario) {
           CURLE_OK &&
       certificate_info != nullptr) {
     result.certificate_count = certificate_info->num_of_certs;
+    for (int certificate_index = 0;
+         certificate_index < certificate_info->num_of_certs;
+         ++certificate_index) {
+      for (const curl_slist *entry =
+               certificate_info->certinfo[certificate_index];
+           entry != nullptr; entry = entry->next) {
+        if (entry->data != nullptr) {
+          result.certificate_info.emplace_back(entry->data);
+        }
+      }
+    }
   }
   result.saw_live_tls_session = server.saw_live_tls_session();
   result.negotiated_version = server.negotiated_tls_version();
@@ -552,6 +564,16 @@ TlsTransferResult DriveTlsScenario(const Scenario &scenario) {
   curl_easy_cleanup(easy);
   curl_slist_free_all(connect_to);
   return result;
+}
+
+bool HasCertificateInfoPrefix(const TlsTransferResult &result,
+                              const std::string &prefix) {
+  for (const std::string &entry : result.certificate_info) {
+    if (entry.compare(0, prefix.size(), prefix) == 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void TestTlsServerCompletesVerifiedTransfer() {
@@ -572,6 +594,31 @@ void TestTlsServerCompletesVerifiedTransfer() {
          "default TLS seed no longer negotiates TLS 1.3");
   Expect(result.handshake_count == 1,
          "single TLS transfer completed an unexpected number of handshakes");
+}
+
+void TestTlsAllKeyTypesReachCertificateInfo() {
+  Scenario scenario = MakeTlsScenario("certinfo-all-key-types", "keys");
+  scenario.set_tls_certificate_chain(
+      curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES);
+  AddBoolOption(&scenario, curl::fuzzer::proto::CURLOPT_CERTINFO, true);
+
+  const TlsTransferResult result = DriveTlsScenario(scenario);
+  Expect(result.code == CURLE_OK && result.response == "keys",
+         "all-key-types TLS chain did not complete a verified transfer");
+  Expect(result.verify_result == 0,
+         "auxiliary certificate types changed leaf verification");
+  Expect(result.certificate_count == 4,
+         "all-key-types TLS peer did not send every selected certificate");
+  Expect(HasCertificateInfoPrefix(result, "RSA Public Key:"),
+         "RSA certificate did not reach ossl_certchain's key formatter");
+#ifndef OPENSSL_NO_DSA
+  Expect(HasCertificateInfoPrefix(result, "dsa(p):"),
+         "DSA certificate did not reach ossl_certchain's key formatter");
+#endif
+  Expect(HasCertificateInfoPrefix(result, "dh(p):"),
+         "DH certificate did not reach ossl_certchain's key formatter");
+  Expect(HasCertificateInfoPrefix(result, "Serial Number:-"),
+         "negative certificate serial did not reach ossl_certchain");
 }
 
 void TestTls12OptionsForceNegotiatedVersion() {
@@ -954,6 +1001,7 @@ int main() {
 #if defined(PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
   TestHttpsigAlgorithmsEmitSignatureHeaders();
   TestTlsServerCompletesVerifiedTransfer();
+  TestTlsAllKeyTypesReachCertificateInfo();
   TestTls12OptionsForceNegotiatedVersion();
   TestTlsPublicKeyPins();
   TestTlsRedirectReusesSession();

--- a/tests/target_policy_test.cc
+++ b/tests/target_policy_test.cc
@@ -159,6 +159,8 @@ void TestDeepHttpPolicy() {
 void TestFastHttpsPolicy() {
   Scenario scenario = ScenarioWithBackpressure(SCHEME_HTTP, 4096, 17);
   scenario.set_host_path("mutated.example:8443/a/path?query#fragment");
+  scenario.set_tls_certificate_chain(
+      curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES);
 
   ApplyTargetPolicy(&scenario, TargetProfile::kFastHttps);
 
@@ -168,6 +170,50 @@ void TestFastHttpsPolicy() {
          "fast HTTPS policy retained backpressure");
   Expect(scenario.host_path() == "tls.test/a/path?query#fragment",
          "fast HTTPS policy did not retain URL suffix under the trusted host");
+  Expect(scenario.tls_certificate_chain() ==
+             curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES,
+         "fast HTTPS policy discarded its certificate-chain selector");
+}
+
+void TestFastHttpsPolicyRejectsUnknownCertificateChain() {
+  Scenario scenario;
+  scenario.set_tls_certificate_chain(
+      static_cast<curl::fuzzer::proto::TlsCertificateChainProfile>(99));
+
+  ApplyTargetPolicy(&scenario, TargetProfile::kFastHttps);
+
+  Expect(scenario.tls_certificate_chain() ==
+             curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC,
+         "fast HTTPS policy retained an unknown certificate-chain selector");
+}
+
+void TestNonHttpsPoliciesDiscardTlsCertificateChains() {
+  constexpr TargetProfile kNonHttpsPolicies[] = {
+      TargetProfile::kFastHttp,
+      TargetProfile::kDeepHttp,
+      TargetProfile::kH2Proxy,
+      TargetProfile::kFastWebSocket,
+      TargetProfile::kFastSecureWebSocket,
+      TargetProfile::kFastTelnet,
+      TargetProfile::kFastFtp,
+      TargetProfile::kFastTftp,
+      TargetProfile::kApi,
+      TargetProfile::kMulti,
+      TargetProfile::kTiming,
+  };
+
+  for (const TargetProfile profile : kNonHttpsPolicies) {
+    Scenario scenario;
+    scenario.set_host_path("example.test/");
+    scenario.set_tls_certificate_chain(
+        curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES);
+
+    ApplyTargetPolicy(&scenario, profile);
+
+    Expect(scenario.tls_certificate_chain() ==
+               curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC,
+           "a non-HTTPS policy retained TLS certificate-chain work");
+  }
 }
 
 void TestH2ProxyPolicy() {
@@ -942,6 +988,8 @@ void TestCompatibilityProfileIsNoOp() {
   scenario.set_host_path("compatibility.example/");
   scenario.mutable_api_plan()->set_duplicate_easy(true);
   scenario.mutable_multi_plan()->set_transfer_count(4);
+  scenario.set_tls_certificate_chain(
+      curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES);
   scenario.add_request_headers("X-Compatibility: retained");
   const std::string before = scenario.SerializeAsString();
 
@@ -957,6 +1005,8 @@ int main() {
   TestFastHttpPolicy();
   TestDeepHttpPolicy();
   TestFastHttpsPolicy();
+  TestFastHttpsPolicyRejectsUnknownCertificateChain();
+  TestNonHttpsPoliciesDiscardTlsCertificateChains();
   TestH2ProxyPolicy();
   TestFastWebSocketPolicy();
   TestFastSecureWebSocketPolicy();

--- a/tests/test_tls_scenarios.py
+++ b/tests/test_tls_scenarios.py
@@ -58,6 +58,11 @@ def test_tls_controls_are_reachable_as_copied_values() -> None:
 def test_tls_seeds_retain_version_pin_and_session_correlations() -> None:
     """Protect values that blind protobuf mutation is unlikely to recreate."""
     expected_tokens = {
+        "https_certinfo_all_key_types.textproto": (
+            "TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES",
+            "CURLOPT_CERTINFO bool_value: true",
+            "all-keys",
+        ),
         "https_tls13_certinfo.textproto": (
             "CURLOPT_CERTINFO bool_value: true",
             "CURLOPT_SSL_VERIFYHOST uint_value: 2",


### PR DESCRIPTION
Add a Scenario selector for the HTTPS mock server's certificate chain, while preserving the existing EC-only chain as the default.

Add an alternate chain containing RSA, DSA and DH auxiliary certificates so CURLOPT_CERTINFO reaches every ossl_certchain public-key formatter. Include a deterministic corpus seed and tests for chain selection, verification, certificate count and formatted key data.