### PR TITLE
fuzz: add GnuTLS-backed HTTPS target

### DIFF
--- a/.github/workflows/acr.yml
+++ b/.github/workflows/acr.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build
-          key: acr-build-${{ matrix.sanitizer }}-${{ matrix.engine }}-${{ hashFiles('CMakeLists.txt', 'scripts/compile_target.sh', 'scripts/ossfuzzdeps.sh', 'scripts/trim_cache.sh', 'ossfuzz.sh') }}
+          key: acr-build-${{ matrix.sanitizer }}-${{ matrix.engine }}-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake', 'scripts/compile_target.sh', 'scripts/ossfuzzdeps.sh', 'scripts/trim_cache.sh', 'ossfuzz.sh') }}
           restore-keys: |
             acr-build-${{ matrix.sanitizer }}-${{ matrix.engine }}-
 
@@ -97,7 +97,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: build
-          key: acr-build-${{ matrix.sanitizer }}-${{ matrix.engine }}-${{ hashFiles('CMakeLists.txt', 'scripts/compile_target.sh', 'scripts/ossfuzzdeps.sh', 'scripts/trim_cache.sh', 'ossfuzz.sh') }}
+          key: acr-build-${{ matrix.sanitizer }}-${{ matrix.engine }}-${{ hashFiles('CMakeLists.txt', 'cmake/*.cmake', 'scripts/compile_target.sh', 'scripts/ossfuzzdeps.sh', 'scripts/trim_cache.sh', 'ossfuzz.sh') }}
 
       - name: Test image
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.CACHE_PATH }}
-          key: ossfuzz-build-v2-${{ runner.os }}-address-x86_64-${{ hashFiles('.curl-fuzzer/CMakeLists.txt', '.curl-fuzzer/scripts/compile_target.sh', '.curl-fuzzer/scripts/ossfuzzdeps.sh', '.curl-fuzzer/scripts/trim_cache.sh', '.curl-fuzzer/ossfuzz.sh') }}
+          key: ossfuzz-build-v2-${{ runner.os }}-address-x86_64-${{ hashFiles('.curl-fuzzer/CMakeLists.txt', '.curl-fuzzer/cmake/*.cmake', '.curl-fuzzer/scripts/compile_target.sh', '.curl-fuzzer/scripts/ossfuzzdeps.sh', '.curl-fuzzer/scripts/trim_cache.sh', '.curl-fuzzer/ossfuzz.sh') }}
           restore-keys: |
             ossfuzz-build-v2-${{ runner.os }}-address-x86_64-
 
@@ -93,7 +93,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.CACHE_PATH }}
-          key: ossfuzz-build-v2-${{ runner.os }}-address-x86_64-${{ hashFiles('.curl-fuzzer/CMakeLists.txt', '.curl-fuzzer/scripts/compile_target.sh', '.curl-fuzzer/scripts/ossfuzzdeps.sh', '.curl-fuzzer/scripts/trim_cache.sh', '.curl-fuzzer/ossfuzz.sh') }}
+          key: ossfuzz-build-v2-${{ runner.os }}-address-x86_64-${{ hashFiles('.curl-fuzzer/CMakeLists.txt', '.curl-fuzzer/cmake/*.cmake', '.curl-fuzzer/scripts/compile_target.sh', '.curl-fuzzer/scripts/ossfuzzdeps.sh', '.curl-fuzzer/scripts/trim_cache.sh', '.curl-fuzzer/ossfuzz.sh') }}
 
       # Archive the fuzzer output (which maintains permissions)
       - name: Create fuzz tar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,6 +422,18 @@ else()
     add_custom_target(openldap_external)
 endif()
 
+# A second TLS backend is useful only for the 64-bit structured suite. Keep it
+# out of MSan until the complete crypto dependency stack can be built against
+# an instrumented C library; this mirrors the existing OpenSSL exclusion.
+set(BUILD_GNUTLS_VARIANT FALSE)
+set(GNUTLS_EXTERNAL_DEP "")
+set(GNUTLS_CACHE_INSTALL_DIRS "")
+if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386" AND
+   NOT "$ENV{SANITIZER}" STREQUAL "memory")
+    set(BUILD_GNUTLS_VARIANT TRUE)
+    include(${CMAKE_SOURCE_DIR}/cmake/GnuTLSDependencies.cmake)
+endif()
+
 # Group non-curl dependencies into a single target
 add_custom_target(deps
     DEPENDS
@@ -432,22 +444,19 @@ add_custom_target(deps
         brotli_external
         libidn2_external
         openldap_external
+        ${GNUTLS_EXTERNAL_DEP}
 )
 
 # Now for the main dependencies!
 #
-# Compile and install curl.
+# Compile and install curl. The existing target remains the default/OpenSSL
+# build so cached artefacts and every established fuzzer retain their names.
+# The GnuTLS variant consumes the same source checkout from a separate build
+# and install tree.
 set(CURL_INSTALL_DIR ${CMAKE_BINARY_DIR}/curl-install)
+set(CURL_GNUTLS_INSTALL_DIR ${CMAKE_BINARY_DIR}/curl-gnutls-install)
 
-# Determine SSL and nghttp2 options
-if(TARGET openssl_external)
-    set(CURL_SSL_OPTION -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=${OPENSSL_INSTALL_DIR})
-else()
-    set(CURL_SSL_OPTION -DCURL_USE_OPENSSL=OFF)
-endif()
-
-set(CURL_CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX=${CURL_INSTALL_DIR}
+set(CURL_COMMON_CMAKE_ARGS
     -DCMAKE_INSTALL_LIBDIR=lib
     -DCURL_DISABLE_INSTALL=ON
     -DBUILD_SHARED_LIBS=OFF
@@ -459,6 +468,11 @@ set(CURL_CMAKE_ARGS
     -DENABLE_DEBUG=ON
     -DCURL_HIDDEN_SYMBOLS=OFF
     -DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
+    # TLS scenarios install their test CA from an in-memory blob. Avoid
+    # auto-detecting and reparsing the container's host trust store on every
+    # fuzz iteration, which is particularly expensive in the GnuTLS backend.
+    -DCURL_CA_BUNDLE=none
+    -DCURL_CA_PATH=none
     -DCURL_USE_LIBPSL=OFF
     # These protocol parsers have no feature bits. Make their coverage
     # dependencies explicit and verify curl's advertised protocol list too,
@@ -477,7 +491,6 @@ set(CURL_CMAKE_ARGS
     # TLS backend. ECH consumes these records when TLS is present, while the
     # standalone DoH target can exercise their wire decoder independently.
     -DUSE_HTTPSRR=ON
-    ${CURL_SSL_OPTION}
     -DZLIB_INCLUDE_DIR=${ZLIB_INSTALL_DIR}/include
     -DZLIB_LIBRARY=${ZLIB_STATIC_LIB}
     -DNGHTTP2_INCLUDE_DIR=${NGHTTP2_INSTALL_DIR}/include
@@ -495,15 +508,6 @@ set(CURL_CMAKE_ARGS
     -DLDAP_LIBRARY=${OPENLDAP_STATIC_LIB_LDAP}
     -DLDAP_LBER_LIBRARY=${OPENLDAP_STATIC_LIB_LBER}
 )
-
-# These experimental features need crypto/TLS backend support. The bundled
-# OpenSSL 4.x provides both HTTP Message Signature primitives and the ECH API;
-# MSan intentionally has no OpenSSL and therefore retains curl's defaults.
-if(TARGET openssl_external)
-    list(APPEND CURL_CMAKE_ARGS
-        -DCURL_DISABLE_HTTPSIG=OFF
-        -DUSE_ECH=ON)
-endif()
 
 # Baseline CFLAGS passed to curl's own CMake. Always defines UNITTESTS so
 # the UNITTEST macro in curl_setup.h flips from `static` to empty, giving
@@ -523,69 +527,138 @@ if(ENABLE_COVERAGE)
     set(_CURL_BASE_CXX_FLAGS "${_CURL_BASE_CXX_FLAGS} ${_COV_COMPILE_FLAGS_STR}")
 endif()
 
-list(APPEND CURL_CMAKE_ARGS
+set(CURL_DEFAULT_CMAKE_ARGS
+    -DCMAKE_INSTALL_PREFIX=${CURL_INSTALL_DIR}
+    ${CURL_COMMON_CMAKE_ARGS}
     "-DCMAKE_C_FLAGS=${_CURL_BASE_C_FLAGS}"
     "-DCMAKE_CXX_FLAGS=${_CURL_BASE_CXX_FLAGS}"
 )
-
-set(CURL_INSTALL_COMMAND
-    INSTALL_COMMAND
-        ${CMAKE_COMMAND} -E remove_directory ${CURL_INSTALL_DIR}
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CURL_INSTALL_DIR}/lib
-    COMMAND ${CMAKE_COMMAND} -E make_directory
-        ${CURL_INSTALL_DIR}/include/curl
-    COMMAND ${CMAKE_COMMAND} -E make_directory ${CURL_INSTALL_DIR}/utfuzzer
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-        <SOURCE_DIR>/include/curl ${CURL_INSTALL_DIR}/include/curl
-    COMMAND ${CMAKE_COMMAND} -E rm -f
-        ${CURL_INSTALL_DIR}/include/curl/Makefile.am
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        <BINARY_DIR>/lib/libcurl.a ${CURL_INSTALL_DIR}/lib/libcurl.a
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        <SOURCE_DIR>/lib/bufq.h ${CURL_INSTALL_DIR}/utfuzzer/
-    COMMAND ${CMAKE_COMMAND} -E touch
-        ${CURL_INSTALL_DIR}/utfuzzer/curl_setup.h
-)
-
-# Conditionally check to see if there's a source directory or not.
-# If there is, use it. Otherwise, download the latest version.
-#
-if(NOT "$ENV{CURL_SOURCE_DIR}" STREQUAL "")
-    message(STATUS "Building curl from source directory: $ENV{CURL_SOURCE_DIR}")
-    ExternalProject_Add(curl_external
-        SOURCE_DIR $ENV{CURL_SOURCE_DIR}
-        PATCH_COMMAND ${CMAKE_COMMAND} -E echo "pre-build commands"
-        ${CURL_INSTALL_COMMAND}
-        CMAKE_ARGS ${CURL_CMAKE_ARGS}
-        BUILD_BYPRODUCTS ${CURL_INSTALL_DIR}/lib/libcurl.a
-    )
+if(TARGET openssl_external)
+    list(APPEND CURL_DEFAULT_CMAKE_ARGS
+        -DCURL_ENABLE_SSL=ON
+        -DCURL_USE_OPENSSL=ON
+        -DCURL_USE_GNUTLS=OFF
+        -DOPENSSL_ROOT_DIR=${OPENSSL_INSTALL_DIR}
+        -DCURL_DISABLE_HTTPSIG=OFF
+        -DUSE_ECH=ON)
 else()
-    message(STATUS "Building curl from git master")
-    set(CURL_URL "https://github.com/curl/curl")
-    ExternalProject_Add(curl_external
-        GIT_REPOSITORY ${CURL_URL}
-        GIT_SHALLOW 1
-        PREFIX ${CMAKE_BINARY_DIR}/curl
-        PATCH_COMMAND ${CMAKE_COMMAND} -E echo "pre-build commands"
-        ${CURL_INSTALL_COMMAND}
-        CMAKE_ARGS ${CURL_CMAKE_ARGS}
-        BUILD_BYPRODUCTS ${CURL_INSTALL_DIR}/lib/libcurl.a
+    list(APPEND CURL_DEFAULT_CMAKE_ARGS
+        -DCURL_USE_OPENSSL=OFF
+        -DCURL_USE_GNUTLS=OFF)
+endif()
+
+if(BUILD_GNUTLS_VARIANT)
+    set(CURL_GNUTLS_CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${CURL_GNUTLS_INSTALL_DIR}
+        ${CURL_COMMON_CMAKE_ARGS}
+        # Nettle's public bignum.h includes gmp.h. Keep curl's Ed25519 build
+        # on the vendored GMP headers rather than whichever version happens
+        # to be installed on the host.
+        "-DCMAKE_C_FLAGS=${_CURL_BASE_C_FLAGS} -I${GNUTLS_GMP_INCLUDE_DIR}"
+        "-DCMAKE_CXX_FLAGS=${_CURL_BASE_CXX_FLAGS} -I${GNUTLS_GMP_INCLUDE_DIR}"
+        ${GNUTLS_CURL_CMAKE_ARGS}
+        # GnuTLS carries a private libunistring in this hermetic build. Linking
+        # curl's bundled libidn2 (and its own libunistring copy) into the same
+        # executable would make symbol resolution depend on archive order.
+        # The default curl build retains IDN coverage.
+        -DUSE_LIBIDN2=OFF
+        -DCURL_DISABLE_HTTPSIG=OFF
+        -DUSE_ECH=OFF
     )
 endif()
 
-set(CURL_STATIC_LIB ${CURL_INSTALL_DIR}/lib/libcurl.a)
-set(CURL_DEPS
+function(curl_add_external_variant _target _install_dir)
+    cmake_parse_arguments(VARIANT "" "" "CMAKE_ARGS;SOURCE_ARGS;DEPENDS" ${ARGN})
+    ExternalProject_Add(${_target}
+        ${VARIANT_SOURCE_ARGS}
+        PATCH_COMMAND ${CMAKE_COMMAND} -E echo "pre-build commands"
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E remove_directory ${_install_dir}
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${_install_dir}/lib
+        COMMAND ${CMAKE_COMMAND} -E make_directory
+            ${_install_dir}/include/curl
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${_install_dir}/utfuzzer
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+            <SOURCE_DIR>/include/curl ${_install_dir}/include/curl
+        COMMAND ${CMAKE_COMMAND} -E rm -f
+            ${_install_dir}/include/curl/Makefile.am
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            <BINARY_DIR>/lib/libcurl.a ${_install_dir}/lib/libcurl.a
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            <SOURCE_DIR>/lib/bufq.h ${_install_dir}/utfuzzer/
+        COMMAND ${CMAKE_COMMAND} -E touch
+            ${_install_dir}/utfuzzer/curl_setup.h
+        CMAKE_ARGS ${VARIANT_CMAKE_ARGS}
+        BUILD_BYPRODUCTS ${_install_dir}/lib/libcurl.a
+    )
+    add_dependencies(${_target} ${VARIANT_DEPENDS})
+endfunction()
+
+# Conditionally use the source directory supplied by OSS-Fuzz. The standalone
+# fallback lets the primary project perform the single clone; the GnuTLS build
+# then waits for and reuses that checkout rather than creating a second source
+# path in LLVM coverage data.
+if(NOT "$ENV{CURL_SOURCE_DIR}" STREQUAL "")
+    message(STATUS "Building curl variants from source directory: $ENV{CURL_SOURCE_DIR}")
+    set(CURL_DEFAULT_SOURCE_ARGS
+        SOURCE_DIR $ENV{CURL_SOURCE_DIR}
+        DOWNLOAD_COMMAND ""
+        UPDATE_COMMAND "")
+else()
+    message(STATUS "Building curl variants from git master")
+    set(CURL_DEFAULT_SOURCE_ARGS
+        GIT_REPOSITORY https://github.com/curl/curl
+        GIT_SHALLOW 1
+        PREFIX ${CMAKE_BINARY_DIR}/curl)
+endif()
+
+set(CURL_COMMON_DEPS
     nghttp2_external
-    ${OPENSSL_DEP}
     zlib_external
     zstd_external
     brotli_external
-    libidn2_external
     openldap_external
 )
+set(CURL_DEPS ${CURL_COMMON_DEPS} libidn2_external ${OPENSSL_DEP})
+curl_add_external_variant(curl_external ${CURL_INSTALL_DIR}
+    CMAKE_ARGS ${CURL_DEFAULT_CMAKE_ARGS}
+    SOURCE_ARGS ${CURL_DEFAULT_SOURCE_ARGS}
+    DEPENDS ${CURL_DEPS})
 
-# Add dependencies for curl
-add_dependencies(curl_external ${CURL_DEPS})
+if(BUILD_GNUTLS_VARIANT)
+    if(NOT "$ENV{CURL_SOURCE_DIR}" STREQUAL "")
+        set(CURL_GNUTLS_SOURCE_ARGS
+            SOURCE_DIR $ENV{CURL_SOURCE_DIR}
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND "")
+        set(CURL_GNUTLS_SOURCE_DEP "")
+    else()
+        ExternalProject_Get_Property(curl_external SOURCE_DIR)
+        set(CURL_SHARED_SOURCE_DIR ${SOURCE_DIR})
+        unset(SOURCE_DIR)
+        set(CURL_GNUTLS_SOURCE_ARGS
+            SOURCE_DIR ${CURL_SHARED_SOURCE_DIR}
+            DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E echo
+                "Reusing curl source from curl_external"
+            UPDATE_COMMAND "")
+        # The download step is part of curl_external in standalone builds.
+        # Waiting for that project avoids racing a configure against its clone.
+        set(CURL_GNUTLS_SOURCE_DEP curl_external)
+    endif()
+    set(CURL_GNUTLS_DEPS
+        ${CURL_COMMON_DEPS}
+        ${GNUTLS_EXTERNAL_DEP}
+        ${CURL_GNUTLS_SOURCE_DEP})
+    curl_add_external_variant(curl_gnutls_external
+        ${CURL_GNUTLS_INSTALL_DIR}
+        CMAKE_ARGS ${CURL_GNUTLS_CMAKE_ARGS}
+        SOURCE_ARGS ${CURL_GNUTLS_SOURCE_ARGS}
+        DEPENDS ${CURL_GNUTLS_DEPS})
+endif()
+
+set(CURL_STATIC_LIB ${CURL_INSTALL_DIR}/lib/libcurl.a)
+set(CURL_GNUTLS_STATIC_LIB
+    ${CURL_GNUTLS_INSTALL_DIR}/lib/libcurl.a)
 
 # Now it's time for the main targets!
 
@@ -595,6 +668,10 @@ set(CURL_INCLUDE_DIRS
     ${CURL_INSTALL_DIR}/utfuzzer
 )
 set(CURL_LIB_DIR ${CURL_INSTALL_DIR}/lib)
+set(CURL_GNUTLS_INCLUDE_DIRS
+    ${CURL_GNUTLS_INSTALL_DIR}/include
+    ${CURL_GNUTLS_INSTALL_DIR}/utfuzzer
+)
 
 # Fuzzing engine
 if(NOT "$ENV{LIB_FUZZING_ENGINE}" STREQUAL "")
@@ -636,12 +713,57 @@ set(CURL_STATIC_DEPENDENCY_LIBS
     ${OPENLDAP_STATIC_LIB_LDAP}
     ${OPENLDAP_STATIC_LIB_LBER}
 )
-set(COMMON_LINK_LIBS
-    ${CURL_LIB_DIR}/libcurl.a
+
+# Keep the libcurl client backend separate from the OpenSSL-based mock peer.
+# A final executable links one client bundle; the GnuTLS proto bundle adds
+# OpenSSL only to satisfy the server-side TLS implementation.
+add_library(curl_client_default INTERFACE)
+target_include_directories(curl_client_default INTERFACE ${CURL_INCLUDE_DIRS})
+target_link_libraries(curl_client_default INTERFACE
+    ${CURL_STATIC_LIB}
     ${CURL_STATIC_DEPENDENCY_LIBS}
-    ${LIB_FUZZING_ENGINE}
     pthread
-    m
+    m)
+add_dependencies(curl_client_default curl_external ${CURL_DEPS})
+
+if(TARGET openssl_external)
+    add_library(curl_tls_mock_openssl INTERFACE)
+    target_include_directories(curl_tls_mock_openssl INTERFACE
+        ${OPENSSL_INSTALL_DIR}/include)
+    target_link_libraries(curl_tls_mock_openssl INTERFACE
+        ${OPENSSL_STATIC_LIB})
+    add_dependencies(curl_tls_mock_openssl openssl_external)
+endif()
+
+if(BUILD_GNUTLS_VARIANT)
+    add_library(curl_client_gnutls INTERFACE)
+    target_include_directories(curl_client_gnutls INTERFACE
+        ${CURL_GNUTLS_INCLUDE_DIRS})
+    target_link_libraries(curl_client_gnutls INTERFACE
+        ${CURL_GNUTLS_STATIC_LIB}
+        ${NGHTTP2_STATIC_LIB}
+        curl_fuzzer::gnutls_dependencies
+        ${ZLIB_STATIC_LIB}
+        ${ZSTD_STATIC_LIB}
+        ${BROTLI_STATIC_LIBS}
+        ${OPENLDAP_STATIC_LIB_LDAP}
+        ${OPENLDAP_STATIC_LIB_LBER}
+        pthread
+        m)
+    add_dependencies(curl_client_gnutls
+        curl_gnutls_external ${CURL_GNUTLS_DEPS})
+
+    add_library(curl_proto_client_gnutls INTERFACE)
+    target_link_libraries(curl_proto_client_gnutls INTERFACE
+        curl_tls_mock_openssl
+        curl_client_gnutls)
+    add_dependencies(curl_proto_client_gnutls
+        curl_gnutls_external openssl_external)
+endif()
+
+set(COMMON_LINK_LIBS
+    curl_client_default
+    ${LIB_FUZZING_ENGINE}
 )
 set(COMMON_LINK_OPTIONS ${LIB_FUZZING_ENGINE_FLAG} ${COVERAGE_LINK_FLAGS})
 
@@ -686,13 +808,7 @@ if(BUILD_TESTING)
     add_executable(curl_features_test tests/curl_features_test.cc)
     target_compile_features(curl_features_test PRIVATE cxx_std_11)
     target_compile_options(curl_features_test PRIVATE ${COMMON_FLAGS})
-    target_include_directories(curl_features_test PRIVATE ${CURL_INCLUDE_DIRS})
-    target_link_libraries(curl_features_test PRIVATE
-        ${CURL_LIB_DIR}/libcurl.a
-        ${CURL_STATIC_DEPENDENCY_LIBS}
-        pthread
-        m
-    )
+    target_link_libraries(curl_features_test PRIVATE curl_client_default)
     target_link_options(curl_features_test PRIVATE ${COVERAGE_LINK_FLAGS})
     if(TARGET openssl_external)
         target_compile_definitions(curl_features_test PRIVATE
@@ -702,6 +818,25 @@ if(BUILD_TESTING)
     add_test(NAME curl_features_test COMMAND curl_features_test)
     add_dependencies(fuzzer_unit_tests curl_features_test)
 
+    if(BUILD_GNUTLS_VARIANT)
+        add_executable(curl_gnutls_features_test tests/curl_features_test.cc)
+        target_compile_features(curl_gnutls_features_test PRIVATE cxx_std_11)
+        target_compile_options(curl_gnutls_features_test PRIVATE ${COMMON_FLAGS})
+        target_compile_definitions(curl_gnutls_features_test PRIVATE
+            CURL_FUZZER_EXPECT_GNUTLS
+            CURL_FUZZER_EXPECT_HTTPSRR
+            CURL_FUZZER_EXPECT_HTTPSIG)
+        target_link_libraries(curl_gnutls_features_test PRIVATE
+            curl_client_gnutls)
+        target_link_options(curl_gnutls_features_test PRIVATE
+            ${COVERAGE_LINK_FLAGS})
+        add_dependencies(curl_gnutls_features_test
+            curl_gnutls_external ${CURL_GNUTLS_DEPS})
+        add_test(NAME curl_gnutls_features_test
+            COMMAND curl_gnutls_features_test)
+        add_dependencies(fuzzer_unit_tests curl_gnutls_features_test)
+    endif()
+
     add_executable(legacy_protocol_allowlist_test
         legacy_protocol_allowlist.cc
         tests/legacy_protocol_allowlist_test.cc
@@ -709,15 +844,9 @@ if(BUILD_TESTING)
     target_compile_features(legacy_protocol_allowlist_test PRIVATE cxx_std_11)
     target_compile_options(legacy_protocol_allowlist_test PRIVATE ${COMMON_FLAGS})
     target_include_directories(legacy_protocol_allowlist_test PRIVATE
-        ${CMAKE_SOURCE_DIR}
-        ${CURL_INCLUDE_DIRS}
-    )
+        ${CMAKE_SOURCE_DIR})
     target_link_libraries(legacy_protocol_allowlist_test PRIVATE
-        ${CURL_LIB_DIR}/libcurl.a
-        ${CURL_STATIC_DEPENDENCY_LIBS}
-        pthread
-        m
-    )
+        curl_client_default)
     target_link_options(legacy_protocol_allowlist_test PRIVATE
         ${COVERAGE_LINK_FLAGS})
     add_dependencies(legacy_protocol_allowlist_test curl_external ${CURL_DEPS})
@@ -1029,6 +1158,22 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     # entrypoint binds its TargetProfile in ordinary C++, keeping build-system
     # wiring independent of mutation and execution behaviour.
     function(curl_add_proto_fuzzer _name)
+        set(_curl_client curl_client_default)
+        set(_curl_target_deps ${FUZZ_DEPS})
+        set(_curl_include_dirs ${CURL_INCLUDE_DIRS})
+        if(ARGC GREATER 1)
+            if(NOT "${ARGV1}" STREQUAL "gnutls" OR
+               NOT BUILD_GNUTLS_VARIANT)
+                message(FATAL_ERROR
+                    "Unsupported curl client variant for ${_name}: ${ARGV1}")
+            endif()
+            set(_curl_client curl_proto_client_gnutls)
+            set(_curl_target_deps
+                curl_gnutls_external
+                ${CURL_GNUTLS_DEPS}
+                ${LIB_FUZZING_ENGINE_DEP})
+            set(_curl_include_dirs ${CURL_GNUTLS_INCLUDE_DIRS})
+        endif()
         add_executable(${_name}
             fuzzer_entrypoints/${_name}.cc
             $<TARGET_OBJECTS:curl_fuzzer_proto_runtime>
@@ -1037,7 +1182,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         target_compile_options(${_name} PRIVATE
             ${COMMON_FLAGS} -DFUZZ_PROTOCOLS_HTTP)
         target_include_directories(${_name} PRIVATE
-            ${CURL_INCLUDE_DIRS}
+            ${_curl_include_dirs}
             ${CMAKE_BINARY_DIR}
             ${CMAKE_SOURCE_DIR}
             ${LPM_INSTALL_DIR}/include
@@ -1045,8 +1190,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
             ${LPM_PB_INCLUDE}
         )
         target_link_libraries(${_name} PRIVATE
-            ${CURL_LIB_DIR}/libcurl.a
-            ${CURL_STATIC_DEPENDENCY_LIBS}
+            ${_curl_client}
             ${LIB_FUZZING_ENGINE}
             # -Wl,@file: ld reads the response file and substitutes its
             # contents — the absolute paths to every .a from LPM's install +
@@ -1059,12 +1203,10 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
             # The -Wl, prefix is what keeps CMake from mangling "@file" into
             # "-l@file" (treating it as a library name).
             "-Wl,@${LPM_LINK_RSP}"
-            pthread
-            m
         )
         target_link_options(${_name} PRIVATE ${COMMON_LINK_OPTIONS})
         add_dependencies(${_name}
-            ${FUZZ_DEPS}
+            ${_curl_target_deps}
             curl_fuzzer_proto_runtime
             libprotobuf_mutator_external
             lpm_link_rsp
@@ -1079,6 +1221,9 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     curl_add_proto_fuzzer(curl_fuzzer_proto_http)
     curl_add_proto_fuzzer(curl_fuzzer_proto_http_deep)
     curl_add_proto_fuzzer(curl_fuzzer_proto_https)
+    if(BUILD_GNUTLS_VARIANT)
+        curl_add_proto_fuzzer(curl_fuzzer_proto_https_gnutls gnutls)
+    endif()
     curl_add_proto_fuzzer(curl_fuzzer_proto_h2_proxy)
     curl_add_proto_fuzzer(curl_fuzzer_proto_ws)
     curl_add_proto_fuzzer(curl_fuzzer_proto_wss)
@@ -1270,6 +1415,10 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     add_dependencies(curl_fuzzer_proto_http_deep
         curl_fuzzer_proto_http_deep_corpus)
     add_dependencies(curl_fuzzer_proto_https curl_fuzzer_proto_https_corpus)
+    if(BUILD_GNUTLS_VARIANT)
+        add_dependencies(curl_fuzzer_proto_https_gnutls
+            curl_fuzzer_proto_https_corpus)
+    endif()
     add_dependencies(curl_fuzzer_proto_h2_proxy
         curl_fuzzer_proto_h2_proxy_corpus)
     add_dependencies(curl_fuzzer_proto_ws curl_fuzzer_proto_ws_corpus)
@@ -1351,7 +1500,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         # wall-clock waits. This catches script-order, connection-budget, and
         # old-peer lifetime regressions at the callback boundary where they
         # would otherwise look like ordinary curl transfer failures.
-        add_executable(mock_server_test
+        set(MOCK_SERVER_TEST_SOURCES
             tests/mock_server_test.cc
             proto_fuzzer/api_lifecycle.cc
             proto_fuzzer/mock_server.cc
@@ -1367,36 +1516,42 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
             proto_fuzzer/ws_frame.cc
             ${GEN_PB_CC}
         )
-        target_compile_features(mock_server_test PRIVATE cxx_std_17)
-        target_compile_options(mock_server_test PRIVATE ${COMMON_FLAGS})
-        target_include_directories(mock_server_test PRIVATE
-            ${CURL_INCLUDE_DIRS}
-            ${CMAKE_BINARY_DIR}
-            ${CMAKE_SOURCE_DIR}
-            ${LPM_PB_INCLUDE}
-        )
-        if(TARGET openssl_external)
-            target_compile_definitions(mock_server_test PRIVATE
-                PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
-            target_include_directories(mock_server_test PRIVATE
-                ${OPENSSL_INSTALL_DIR}/include)
+
+        function(curl_add_mock_server_test _name _curl_client)
+            add_executable(${_name} ${MOCK_SERVER_TEST_SOURCES})
+            target_compile_features(${_name} PRIVATE cxx_std_17)
+            target_compile_options(${_name} PRIVATE ${COMMON_FLAGS})
+            target_include_directories(${_name} PRIVATE
+                ${CMAKE_BINARY_DIR}
+                ${CMAKE_SOURCE_DIR}
+                ${LPM_PB_INCLUDE})
+            if(TARGET openssl_external)
+                target_compile_definitions(${_name} PRIVATE
+                    PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
+                target_include_directories(${_name} PRIVATE
+                    ${OPENSSL_INSTALL_DIR}/include)
+            endif()
+            if(ARGC GREATER 2)
+                target_compile_definitions(${_name} PRIVATE ${ARGV2})
+            endif()
+            target_link_libraries(${_name} PRIVATE
+                ${_curl_client}
+                "-Wl,@${LPM_LINK_RSP}")
+            target_link_options(${_name} PRIVATE ${COVERAGE_LINK_FLAGS})
+            add_dependencies(${_name}
+                ${_curl_client}
+                libprotobuf_mutator_external
+                lpm_link_rsp)
+            add_test(NAME ${_name} COMMAND ${_name})
+            set_tests_properties(${_name} PROPERTIES TIMEOUT 5)
+            add_dependencies(fuzzer_unit_tests ${_name})
+        endfunction()
+
+        curl_add_mock_server_test(mock_server_test curl_client_default)
+        if(BUILD_GNUTLS_VARIANT)
+            curl_add_mock_server_test(mock_server_gnutls_test
+                curl_proto_client_gnutls CURL_FUZZER_EXPECT_GNUTLS)
         endif()
-        target_link_libraries(mock_server_test PRIVATE
-            ${CURL_LIB_DIR}/libcurl.a
-            ${CURL_STATIC_DEPENDENCY_LIBS}
-            "-Wl,@${LPM_LINK_RSP}"
-            pthread
-            m
-        )
-        target_link_options(mock_server_test PRIVATE ${COVERAGE_LINK_FLAGS})
-        add_dependencies(mock_server_test
-            ${FUZZ_DEPS}
-            libprotobuf_mutator_external
-            lpm_link_rsp
-        )
-        add_test(NAME mock_server_test COMMAND mock_server_test)
-        set_tests_properties(mock_server_test PROPERTIES TIMEOUT 5)
-        add_dependencies(fuzzer_unit_tests mock_server_test)
 
         # Keep concurrent scheduling checks independent of the TLS and
         # protocol integrations in mock_server_test. This focused executable
@@ -1573,6 +1728,11 @@ set(CACHE_INSTALL_DIRS
 )
 if(DEFINED OPENSSL_INSTALL_DIR)
     list(APPEND CACHE_INSTALL_DIRS ${OPENSSL_INSTALL_DIR})
+endif()
+if(BUILD_GNUTLS_VARIANT)
+    list(APPEND CACHE_INSTALL_DIRS
+        ${GNUTLS_CACHE_INSTALL_DIRS}
+        ${CURL_GNUTLS_INSTALL_DIR})
 endif()
 if(BUILD_GDB)
     list(APPEND CACHE_INSTALL_DIRS ${GDB_INSTALL_DIR})

--- a/cmake/GnuTLSDependencies.cmake
+++ b/cmake/GnuTLSDependencies.cmake
@@ -1,0 +1,308 @@
+# Build the static dependency stack used by curl's GnuTLS backend.
+#
+# GnuTLS can use the libtasn1 and libunistring copies shipped in its release
+# tarball. Curl also calls Nettle directly, so the smallest hermetic stack is
+# GMP -> Nettle -> GnuTLS. All three builds deliberately disable assembler and
+# optional dynamic integrations: sanitizer instrumentation then covers every
+# dependency path and the resulting fuzzer has no non-system runtime library
+# dependency.
+
+include_guard(GLOBAL)
+include(ExternalProject)
+
+if(NOT UNIX)
+    message(FATAL_ERROR "The hermetic GnuTLS dependency stack currently supports Unix hosts only")
+endif()
+
+if(DEFINED MAKE)
+    set(_GNUTLS_DEPS_MAKE ${MAKE})
+elseif(NOT "$ENV{MAKE}" STREQUAL "")
+    set(_GNUTLS_DEPS_MAKE "$ENV{MAKE}")
+else()
+    set(_GNUTLS_DEPS_MAKE make)
+endif()
+
+if(CMAKE_C_COMPILER)
+    set(_GNUTLS_DEPS_CC ${CMAKE_C_COMPILER})
+elseif(NOT "$ENV{CC}" STREQUAL "")
+    set(_GNUTLS_DEPS_CC "$ENV{CC}")
+else()
+    set(_GNUTLS_DEPS_CC cc)
+endif()
+
+# Keep the marker compatible with scripts/trim_cache.sh. The top-level project
+# owns this recipe name; provide the same default when this module is exercised
+# by a small standalone configure project.
+if(NOT DEFINED MINIMAL_INSTALL_RECIPE)
+    set(MINIMAL_INSTALL_RECIPE minimal-install-v1)
+endif()
+if(NOT DEFINED MINIMAL_INSTALL_STAMP_NAME)
+    set(MINIMAL_INSTALL_STAMP_NAME
+        .curl-fuzzer-${MINIMAL_INSTALL_RECIPE})
+endif()
+
+# renovate: datasource=custom.gnu depName=gmp
+set(GNUTLS_GMP_VERSION 6.3.0)
+set(GNUTLS_GMP_INSTALL_DIR
+    ${CMAKE_BINARY_DIR}/gmp-${GNUTLS_GMP_VERSION}-install)
+set(GNUTLS_GMP_INCLUDE_DIR ${GNUTLS_GMP_INSTALL_DIR}/include)
+set(GNUTLS_GMP_STATIC_LIB ${GNUTLS_GMP_INSTALL_DIR}/lib/libgmp.a)
+set(GNUTLS_GMP_INSTALL_STAMP
+    ${GNUTLS_GMP_INSTALL_DIR}/${MINIMAL_INSTALL_STAMP_NAME})
+
+if(NOT EXISTS ${GNUTLS_GMP_INSTALL_STAMP} OR
+   NOT EXISTS ${GNUTLS_GMP_STATIC_LIB})
+    ExternalProject_Add(gnutls_gmp_external
+        URL
+            https://ftp.gnu.org/gnu/gmp/gmp-${GNUTLS_GMP_VERSION}.tar.xz
+            https://ftpmirror.gnu.org/gmp/gmp-${GNUTLS_GMP_VERSION}.tar.xz
+        PREFIX
+            ${CMAKE_BINARY_DIR}/gmp-${GNUTLS_GMP_VERSION}-${MINIMAL_INSTALL_RECIPE}
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND} -E env
+                "CC=${_GNUTLS_DEPS_CC}"
+                "CFLAGS=$ENV{CFLAGS}"
+                "CPPFLAGS=$ENV{CPPFLAGS}"
+                "LDFLAGS=$ENV{LDFLAGS}"
+                <SOURCE_DIR>/configure
+                    --prefix=${GNUTLS_GMP_INSTALL_DIR}
+                    --libdir=${GNUTLS_GMP_INSTALL_DIR}/lib
+                    --disable-shared
+                    --enable-static
+                    --disable-assembly
+                    --disable-fat
+        BUILD_COMMAND ${_GNUTLS_DEPS_MAKE}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E remove_directory ${GNUTLS_GMP_INSTALL_DIR}
+        COMMAND ${_GNUTLS_DEPS_MAKE} install
+        COMMAND ${CMAKE_COMMAND} -E touch ${GNUTLS_GMP_INSTALL_STAMP}
+        BUILD_IN_SOURCE 1
+        BUILD_BYPRODUCTS
+            ${GNUTLS_GMP_STATIC_LIB}
+            ${GNUTLS_GMP_INSTALL_STAMP}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        DOWNLOAD_NO_PROGRESS 1
+    )
+else()
+    message(STATUS
+        "GMP for GnuTLS already installed at ${GNUTLS_GMP_INSTALL_DIR}, skipping build")
+    add_custom_target(gnutls_gmp_external)
+endif()
+
+# renovate: datasource=custom.gnu depName=nettle
+set(GNUTLS_NETTLE_VERSION 3.10.2)
+set(GNUTLS_NETTLE_INSTALL_DIR
+    ${CMAKE_BINARY_DIR}/nettle-${GNUTLS_NETTLE_VERSION}-install)
+set(GNUTLS_NETTLE_INCLUDE_DIR ${GNUTLS_NETTLE_INSTALL_DIR}/include)
+set(GNUTLS_NETTLE_STATIC_LIB
+    ${GNUTLS_NETTLE_INSTALL_DIR}/lib/libnettle.a)
+set(GNUTLS_HOGWEED_STATIC_LIB
+    ${GNUTLS_NETTLE_INSTALL_DIR}/lib/libhogweed.a)
+set(GNUTLS_NETTLE_INSTALL_STAMP
+    ${GNUTLS_NETTLE_INSTALL_DIR}/${MINIMAL_INSTALL_STAMP_NAME})
+
+set(_GNUTLS_NETTLE_PKG_CONFIG_PATH
+    "${GNUTLS_GMP_INSTALL_DIR}/lib/pkgconfig")
+if(NOT "$ENV{PKG_CONFIG_PATH}" STREQUAL "")
+    string(APPEND _GNUTLS_NETTLE_PKG_CONFIG_PATH ":$ENV{PKG_CONFIG_PATH}")
+endif()
+set(_GNUTLS_NETTLE_CPPFLAGS "$ENV{CPPFLAGS}")
+string(APPEND _GNUTLS_NETTLE_CPPFLAGS
+    " -I${GNUTLS_GMP_INCLUDE_DIR}")
+set(_GNUTLS_NETTLE_LDFLAGS "$ENV{LDFLAGS}")
+string(APPEND _GNUTLS_NETTLE_LDFLAGS
+    " -L${GNUTLS_GMP_INSTALL_DIR}/lib")
+
+if(NOT EXISTS ${GNUTLS_NETTLE_INSTALL_STAMP} OR
+   NOT EXISTS ${GNUTLS_NETTLE_STATIC_LIB} OR
+   NOT EXISTS ${GNUTLS_HOGWEED_STATIC_LIB})
+    ExternalProject_Add(gnutls_nettle_external
+        URL
+            https://ftp.gnu.org/gnu/nettle/nettle-${GNUTLS_NETTLE_VERSION}.tar.gz
+            https://ftpmirror.gnu.org/nettle/nettle-${GNUTLS_NETTLE_VERSION}.tar.gz
+        PREFIX
+            ${CMAKE_BINARY_DIR}/nettle-${GNUTLS_NETTLE_VERSION}-${MINIMAL_INSTALL_RECIPE}
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND} -E env
+                "CC=${_GNUTLS_DEPS_CC}"
+                "CFLAGS=$ENV{CFLAGS}"
+                "CPPFLAGS=${_GNUTLS_NETTLE_CPPFLAGS}"
+                "LDFLAGS=${_GNUTLS_NETTLE_LDFLAGS}"
+                "PKG_CONFIG_PATH=${_GNUTLS_NETTLE_PKG_CONFIG_PATH}"
+                <SOURCE_DIR>/configure
+                    --prefix=${GNUTLS_NETTLE_INSTALL_DIR}
+                    --libdir=${GNUTLS_NETTLE_INSTALL_DIR}/lib
+                    --disable-shared
+                    --enable-static
+                    --disable-openssl
+                    --disable-documentation
+                    --disable-assembler
+                    --disable-fat
+        BUILD_COMMAND
+            ${_GNUTLS_DEPS_MAKE} libnettle.a libhogweed.a
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E remove_directory ${GNUTLS_NETTLE_INSTALL_DIR}
+        COMMAND
+            ${_GNUTLS_DEPS_MAKE}
+                install-headers
+                install-static
+                install-pkgconfig
+        COMMAND ${CMAKE_COMMAND} -E touch ${GNUTLS_NETTLE_INSTALL_STAMP}
+        BUILD_IN_SOURCE 1
+        BUILD_BYPRODUCTS
+            ${GNUTLS_NETTLE_STATIC_LIB}
+            ${GNUTLS_HOGWEED_STATIC_LIB}
+            ${GNUTLS_NETTLE_INSTALL_STAMP}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        DOWNLOAD_NO_PROGRESS 1
+    )
+    add_dependencies(gnutls_nettle_external gnutls_gmp_external)
+else()
+    message(STATUS
+        "Nettle for GnuTLS already installed at ${GNUTLS_NETTLE_INSTALL_DIR}, skipping build")
+    add_custom_target(gnutls_nettle_external)
+    add_dependencies(gnutls_nettle_external gnutls_gmp_external)
+endif()
+
+# renovate: datasource=gitlab-tags depName=gnutls/gnutls
+set(GNUTLS_VERSION 3.8.13)
+string(REGEX MATCH "^[0-9]+\\.[0-9]+" GNUTLS_SERIES "${GNUTLS_VERSION}")
+set(GNUTLS_INSTALL_DIR ${CMAKE_BINARY_DIR}/gnutls-${GNUTLS_VERSION}-install)
+set(GNUTLS_INCLUDE_DIR ${GNUTLS_INSTALL_DIR}/include)
+set(GNUTLS_STATIC_LIB ${GNUTLS_INSTALL_DIR}/lib/libgnutls.a)
+set(GNUTLS_INSTALL_STAMP
+    ${GNUTLS_INSTALL_DIR}/${MINIMAL_INSTALL_STAMP_NAME})
+
+set(_GNUTLS_PKG_CONFIG_PATH
+    "${GNUTLS_NETTLE_INSTALL_DIR}/lib/pkgconfig:${GNUTLS_GMP_INSTALL_DIR}/lib/pkgconfig")
+if(NOT "$ENV{PKG_CONFIG_PATH}" STREQUAL "")
+    string(APPEND _GNUTLS_PKG_CONFIG_PATH ":$ENV{PKG_CONFIG_PATH}")
+endif()
+set(_GNUTLS_CPPFLAGS "$ENV{CPPFLAGS}")
+string(APPEND _GNUTLS_CPPFLAGS
+    " -I${GNUTLS_NETTLE_INCLUDE_DIR} -I${GNUTLS_GMP_INCLUDE_DIR}")
+set(_GNUTLS_LDFLAGS "$ENV{LDFLAGS}")
+string(APPEND _GNUTLS_LDFLAGS
+    " -L${GNUTLS_NETTLE_INSTALL_DIR}/lib -L${GNUTLS_GMP_INSTALL_DIR}/lib")
+
+if(NOT EXISTS ${GNUTLS_INSTALL_STAMP} OR
+   NOT EXISTS ${GNUTLS_STATIC_LIB})
+    ExternalProject_Add(gnutls_external
+        URL
+            https://www.gnupg.org/ftp/gcrypt/gnutls/v${GNUTLS_SERIES}/gnutls-${GNUTLS_VERSION}.tar.xz
+        PREFIX
+            ${CMAKE_BINARY_DIR}/gnutls-${GNUTLS_VERSION}-${MINIMAL_INSTALL_RECIPE}
+        CONFIGURE_COMMAND
+            ${CMAKE_COMMAND} -E env
+                "CC=${_GNUTLS_DEPS_CC}"
+                "CFLAGS=$ENV{CFLAGS}"
+                "CPPFLAGS=${_GNUTLS_CPPFLAGS}"
+                "LDFLAGS=${_GNUTLS_LDFLAGS}"
+                "PKG_CONFIG_PATH=${_GNUTLS_PKG_CONFIG_PATH}"
+                <SOURCE_DIR>/configure
+                    --prefix=${GNUTLS_INSTALL_DIR}
+                    --libdir=${GNUTLS_INSTALL_DIR}/lib
+                    --disable-shared
+                    --enable-static
+                    --disable-doc
+                    --disable-tests
+                    --disable-tools
+                    --disable-cxx
+                    --disable-maintainer-mode
+                    --disable-libdane
+                    --disable-nls
+                    --disable-hardware-acceleration
+                    --with-included-libtasn1
+                    --with-included-unistring
+                    --without-idn
+                    --without-p11-kit
+                    --without-tpm
+                    --with-tpm2=no
+                    --without-zlib
+                    --without-brotli
+                    --without-zstd
+        BUILD_COMMAND ${_GNUTLS_DEPS_MAKE}
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E remove_directory ${GNUTLS_INSTALL_DIR}
+        COMMAND ${_GNUTLS_DEPS_MAKE} install
+        COMMAND ${CMAKE_COMMAND} -E touch ${GNUTLS_INSTALL_STAMP}
+        BUILD_IN_SOURCE 1
+        BUILD_BYPRODUCTS
+            ${GNUTLS_STATIC_LIB}
+            ${GNUTLS_INSTALL_STAMP}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        DOWNLOAD_NO_PROGRESS 1
+    )
+    add_dependencies(gnutls_external gnutls_nettle_external)
+else()
+    message(STATUS
+        "GnuTLS already installed at ${GNUTLS_INSTALL_DIR}, skipping build")
+    add_custom_target(gnutls_external)
+    add_dependencies(gnutls_external gnutls_nettle_external)
+endif()
+
+add_custom_target(gnutls_dependencies DEPENDS gnutls_external)
+
+# Archive order matters when consumers link statically: GnuTLS calls Hogweed
+# and Nettle, while Hogweed and Nettle call GMP.
+set(GNUTLS_STATIC_LIBS
+    ${GNUTLS_STATIC_LIB}
+    ${GNUTLS_HOGWEED_STATIC_LIB}
+    ${GNUTLS_NETTLE_STATIC_LIB}
+    ${GNUTLS_GMP_STATIC_LIB}
+)
+set(GNUTLS_SYSTEM_LIBS ${CMAKE_DL_LIBS})
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+    # GnuTLS' configure records this in Libs.private on Linux. Keep it after
+    # the four archives so Clang can resolve the atomic helpers they use.
+    list(APPEND GNUTLS_SYSTEM_LIBS atomic)
+endif()
+set(GNUTLS_EXTERNAL_DEP gnutls_external)
+set(GNUTLS_CACHE_INSTALL_DIRS
+    ${GNUTLS_GMP_INSTALL_DIR}
+    ${GNUTLS_NETTLE_INSTALL_DIR}
+    ${GNUTLS_INSTALL_DIR}
+)
+
+# Arguments consumed by curl's own CMake configure. The final fuzzer link must
+# still use GNUTLS_STATIC_LIBS because libcurl.a cannot retain private static
+# dependencies.
+set(GNUTLS_CURL_CMAKE_ARGS
+    -DCURL_ENABLE_SSL=ON
+    -DCURL_USE_OPENSSL=OFF
+    -DCURL_USE_GNUTLS=ON
+    -DGNUTLS_INCLUDE_DIR=${GNUTLS_INCLUDE_DIR}
+    -DGNUTLS_LIBRARY=${GNUTLS_STATIC_LIB}
+    -DNETTLE_INCLUDE_DIR=${GNUTLS_NETTLE_INCLUDE_DIR}
+    -DNETTLE_HOGWEED_LIBRARY=${GNUTLS_HOGWEED_STATIC_LIB}
+    -DNETTLE_LIBRARY=${GNUTLS_NETTLE_STATIC_LIB}
+)
+
+# This target is convenient for final fuzzer links. CMake validates interface
+# include paths while generating, before ExternalProject has installed them, so
+# create only the empty directories here; the dependency chain populates them
+# before any consumer is compiled.
+file(MAKE_DIRECTORY
+    ${GNUTLS_INCLUDE_DIR}
+    ${GNUTLS_NETTLE_INCLUDE_DIR}
+    ${GNUTLS_GMP_INCLUDE_DIR})
+add_library(curl_fuzzer_gnutls_dependencies INTERFACE)
+target_include_directories(curl_fuzzer_gnutls_dependencies INTERFACE
+    ${GNUTLS_INCLUDE_DIR}
+    ${GNUTLS_NETTLE_INCLUDE_DIR}
+    ${GNUTLS_GMP_INCLUDE_DIR})
+target_link_libraries(curl_fuzzer_gnutls_dependencies INTERFACE
+    ${GNUTLS_STATIC_LIBS}
+    ${GNUTLS_SYSTEM_LIBS})
+add_dependencies(curl_fuzzer_gnutls_dependencies gnutls_external)
+add_library(curl_fuzzer::gnutls_dependencies ALIAS
+    curl_fuzzer_gnutls_dependencies)
+
+unset(_GNUTLS_DEPS_MAKE)
+unset(_GNUTLS_DEPS_CC)
+unset(_GNUTLS_NETTLE_PKG_CONFIG_PATH)
+unset(_GNUTLS_NETTLE_CPPFLAGS)
+unset(_GNUTLS_NETTLE_LDFLAGS)
+unset(_GNUTLS_PKG_CONFIG_PATH)
+unset(_GNUTLS_CPPFLAGS)
+unset(_GNUTLS_LDFLAGS)

--- a/fuzzer_entrypoints/curl_fuzzer_proto_https_gnutls.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_https_gnutls.cc
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include "proto_fuzzer/fuzzer_main.h"
+
+namespace {
+
+// Bind the GnuTLS client binary to the same focused HTTPS policy as the
+// original OpenSSL-backed lane. The linked libcurl variant, rather than fuzz
+// input, selects the client TLS backend for the lifetime of the process.
+using Fuzzer = proto_fuzzer::ProtoFuzzerEntrypoint<
+    proto_fuzzer::TargetProfile::kFastHttps>;
+
+} // namespace
+
+// Keep all three libFuzzer ABI hooks in the same-named source so OSS-Fuzz and
+// Fuzz Introspector give this backend its own target identity and corpus.
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
+                                      std::size_t size) {
+  return Fuzzer::TestOneInput(data, size);
+}

--- a/ossconfig/curl_fuzzer_proto_https_gnutls.options
+++ b/ossconfig/curl_fuzzer_proto_https_gnutls.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32768

--- a/ossfuzz.sh
+++ b/ossfuzz.sh
@@ -49,16 +49,20 @@ if [[ "${CIFUZZ:-}" == "True" && -n "${OUT:-}" ]]; then
   export BUILD_DIR=${CACHE_ROOT}/build
   mkdir -p "${BUILD_DIR}"
   echo "CIFuzz detected: redirecting BUILD_DIR to ${BUILD_DIR}"
-
-  # Curl is cloned fresh (--depth 1) on every container start, but its CMake
-  # ExternalProject stamp would skip rebuilding if we kept it. Drop the stamps
-  # and the built library so curl (and the fuzzer binaries that link it) get
-  # rebuilt against the current tip. Mirrors the REPLAY_ENABLED handling in
-  # oss-fuzz/projects/curl/build.sh.
-  rm -f "${BUILD_DIR}/curl-install/lib/libcurl.a"
-  rm -f "${BUILD_DIR}"/curl_external-prefix/src/curl_external-stamp/curl_external-{configure,build,install,done}
 fi
 export BUILD_DIR=${BUILD_DIR:-${BUILD_ROOT}/build}
+
+# Curl is cloned fresh (--depth 1) on every CIFuzz container start. Replay
+# builds likewise update that checkout before invoking this script. Invalidate
+# both client variants so a restored ExternalProject stamp cannot retain an
+# archive from the previous curl revision.
+if [[ "${CIFUZZ:-}" == "True" || -n "${REPLAY_ENABLED:-}" ]]; then
+  rm -f "${BUILD_DIR}/curl-install/lib/libcurl.a"
+  rm -f "${BUILD_DIR}/curl-gnutls-install/lib/libcurl.a"
+  for CURL_VARIANT in curl_external curl_gnutls_external; do
+    rm -f "${BUILD_DIR}/${CURL_VARIANT}-prefix/src/${CURL_VARIANT}-stamp/${CURL_VARIANT}-"{configure,build,install,done}
+  done
+fi
 
 # Compile the fuzzers.
 "${SCRIPTDIR}"/compile_target.sh fuzz

--- a/renovate.json
+++ b/renovate.json
@@ -10,10 +10,11 @@
       "customType": "regex",
       "extractVersionTemplate": "^v?(?<version>.*)$",
       "managerFilePatterns": [
-        "CMakeLists.txt"
+        "/(^|/)CMakeLists\\.txt$/",
+        "/^cmake/.*\\.cmake$/"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\r?\\n\\s*set\\([A-Z0-9_]+_VERSION (?<currentValue>\\d+\\.\\d+\\.\\d+)\\)"
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\r?\\n\\s*set\\([A-Z0-9_]+_VERSION (?<currentValue>\\d+(?:\\.\\d+)+)\\)"
       ]
     },
     {
@@ -30,6 +31,12 @@
       "versioningTemplate": "semver"
     }
   ],
+  "customDatasources": {
+    "gnu": {
+      "defaultRegistryUrlTemplate": "https://ftp.gnu.org/gnu/{{packageName}}/",
+      "format": "html"
+    }
+  },
   "packageRules": [
     {
       "matchManagers": [
@@ -60,6 +67,33 @@
         "openssl/openssl"
       ],
       "extractVersion": "^openssl-(?<version>.*)$"
+    },
+    {
+      "matchDatasources": [
+        "custom.gnu"
+      ],
+      "matchPackageNames": [
+        "gmp"
+      ],
+      "extractVersion": "^gmp-(?<version>\\d+\\.\\d+\\.\\d+)\\.tar\\.xz$"
+    },
+    {
+      "matchDatasources": [
+        "custom.gnu"
+      ],
+      "matchPackageNames": [
+        "nettle"
+      ],
+      "extractVersion": "^nettle-(?<version>\\d+(?:\\.\\d+){1,2})\\.tar\\.gz$"
+    },
+    {
+      "matchDatasources": [
+        "gitlab-tags"
+      ],
+      "matchPackageNames": [
+        "gnutls/gnutls"
+      ],
+      "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+)$"
     }
   ]
 }

--- a/scenarios/curl_fuzzer_proto/https/https_gnutls_tls12_priority.textproto
+++ b/scenarios/curl_fuzzer_proto/https/https_gnutls_tls12_priority.textproto
@@ -1,0 +1,13 @@
+# GnuTLS interprets CURLOPT_SSL_CIPHER_LIST as a priority expression. Preserve
+# one valid correlated value so mutation does not have to rediscover its
+# punctuation before reaching the backend's TLS 1.2 handshake paths.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/gnutls-tls12"
+options { option_id: CURLOPT_SSLVERSION uint_value: 393222 }
+options {
+  option_id: CURLOPT_SSL_CIPHER_LIST
+  string_value: "NORMAL:-VERS-ALL:+VERS-TLS1.2"
+}
+connection {
+  initial_response: "HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\ntls12"
+}

--- a/scenarios/curl_fuzzer_proto/https/https_session_redirect.textproto
+++ b/scenarios/curl_fuzzer_proto/https/https_session_redirect.textproto
@@ -1,11 +1,14 @@
 # Closing a redirect response forces a second TLS socket to the same host.
 # Both connections share one per-scenario server context, allowing curl's
 # client session cache to offer the first connection's session on the second.
+# TLS 1.2 uses the same deterministic session mechanism in both backend builds;
+# TLS 1.3 remains covered by https_tls13_certinfo.
 scheme: SCHEME_HTTPS
 host_path: "tls.test/start"
 options { option_id: CURLOPT_FOLLOWLOCATION uint_value: 1 }
 options { option_id: CURLOPT_MAXREDIRS uint_value: 2 }
 options { option_id: CURLOPT_SSL_SESSIONID_CACHE bool_value: true }
+options { option_id: CURLOPT_SSLVERSION uint_value: 393222 }
 connection {
   initial_response: "HTTP/1.1 302 Found\r\nLocation: https://tls.test/final\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
 }

--- a/scripts/compare_fuzzers.py
+++ b/scripts/compare_fuzzers.py
@@ -40,6 +40,7 @@ DEFAULT_TARGETS = (
     "curl_fuzzer_proto_http",
     "curl_fuzzer_proto_http_deep",
     "curl_fuzzer_proto_https",
+    "curl_fuzzer_proto_https_gnutls",
     "curl_fuzzer_proto_h2_proxy",
     "curl_fuzzer_proto_ws",
     "curl_fuzzer_proto_wss",
@@ -50,11 +51,15 @@ DEFAULT_TARGETS = (
     "curl_fuzzer_proto_multi",
     "curl_fuzzer_proto_timing",
 )
+COMPATIBLE_CORPUS_TARGETS = {
+    "curl_fuzzer_proto_https_gnutls": ("curl_fuzzer_proto_https",),
+}
 HISTORICAL_PROTO_CORPUS_TARGETS = frozenset(
     {
         "curl_fuzzer_proto_http",
         "curl_fuzzer_proto_http_deep",
         "curl_fuzzer_proto_https",
+        "curl_fuzzer_proto_https_gnutls",
         "curl_fuzzer_proto_ws",
         "curl_fuzzer_proto_wss",
         "curl_fuzzer_proto_telnet",
@@ -520,16 +525,20 @@ def _corpus_sources(
         return overrides[target]
 
     sources: list[Path] = []
-    checked_in = corpus_root / target
-    if checked_in.is_dir() and any(path.is_file() for path in checked_in.rglob("*")):
-        sources.append(checked_in)
+    compatible_targets = (target, *COMPATIBLE_CORPUS_TARGETS.get(target, ()))
+    for compatible_target in compatible_targets:
+        checked_in = corpus_root / compatible_target
+        if checked_in.is_dir() and any(
+            path.is_file() for path in checked_in.rglob("*")
+        ):
+            sources.append(checked_in)
 
-    seed_archive = baseline_dir / f"{target}_seed_corpus.zip"
-    if seed_archive.is_file():
-        sources.append(seed_archive)
+        seed_archive = baseline_dir / f"{compatible_target}_seed_corpus.zip"
+        if seed_archive.is_file():
+            sources.append(seed_archive)
 
     if public_corpus_root is not None:
-        public_targets = [target]
+        public_targets = list(compatible_targets)
         if target in HISTORICAL_PROTO_CORPUS_TARGETS:
             public_targets.append("curl_fuzzer_proto")
         for public_target in public_targets:

--- a/scripts/fuzz_corpus_helpers.sh
+++ b/scripts/fuzz_corpus_helpers.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 
 # Return the generated corpus directory associated with a binary. Proto lane
-# names currently match their directories; keeping this helper centralizes any
-# future rename without duplicating mappings across packaging and coverage.
+# names normally match their directories. Backend variants reuse the protocol
+# lane's generated seeds while OSS-Fuzz still sees a distinct binary basename.
 fuzz_local_corpus_name() {
-    echo "$1"
+    case "$1" in
+        curl_fuzzer_proto_https_gnutls)
+            echo "curl_fuzzer_proto_https"
+            ;;
+        *)
+            echo "$1"
+            ;;
+    esac
 }
 
 # Resolve the corpus directory produced for a target. A build-tree manifest is
@@ -33,6 +40,13 @@ fuzz_local_corpus_dir() {
 fuzz_public_corpus_names() {
     echo "$1"
     case "$1" in
+        curl_fuzzer_proto_https_gnutls)
+            # Bootstrap the backend variant from the compatible HTTPS corpus as
+            # well as the original mixed Scenario corpus. Once OSS-Fuzz has a
+            # native GnuTLS corpus, the first name above picks it up too.
+            echo "curl_fuzzer_proto_https"
+            echo "curl_fuzzer_proto"
+            ;;
         curl_fuzzer_proto_http|curl_fuzzer_proto_http_deep|curl_fuzzer_proto_https|curl_fuzzer_proto_ws|curl_fuzzer_proto_wss|curl_fuzzer_proto_telnet|curl_fuzzer_proto_ftp|curl_fuzzer_proto_tftp|curl_fuzzer_proto_api|curl_fuzzer_proto_multi|curl_fuzzer_proto_timing)
             echo "curl_fuzzer_proto"
             ;;

--- a/scripts/fuzz_targets
+++ b/scripts/fuzz_targets
@@ -5,6 +5,11 @@ FUZZ_TARGETS_LIST="curl_fuzzer_dict curl_fuzzer_file curl_fuzzer_ftp curl_fuzzer
 # The structured fuzzer is 64-bit only.
 if [ "${ARCHITECTURE:-}" != "i386" ]; then
     FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto curl_fuzzer_proto_http curl_fuzzer_proto_http_deep curl_fuzzer_proto_https curl_fuzzer_proto_h2_proxy curl_fuzzer_proto_ws curl_fuzzer_proto_wss curl_fuzzer_proto_telnet curl_fuzzer_proto_ftp curl_fuzzer_proto_tftp curl_fuzzer_proto_api curl_fuzzer_proto_multi curl_fuzzer_proto_timing"
+    # The GnuTLS dependency stack is intentionally omitted from MemorySanitizer
+    # until all of its static dependencies can be built with MSan instrumentation.
+    if [ "${SANITIZER:-}" != "memory" ]; then
+        FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto_https_gnutls"
+    fi
 fi
 
 export FUZZ_TARGETS="${FUZZ_TARGETS_LIST}"

--- a/scripts/trim_cache.sh
+++ b/scripts/trim_cache.sh
@@ -103,7 +103,7 @@ for install_dir in "${BD}"/*-install; do
     continue
   fi
   case "${install_name}" in
-    curl-install|lpm-*-install|gdb-*-install)
+    curl-install|curl-gnutls-install|lpm-*-install|gdb-*-install)
       continue
       ;;
   esac

--- a/tests/curl_features_test.cc
+++ b/tests/curl_features_test.cc
@@ -9,6 +9,12 @@
 #include <cstdio>
 #include <cstring>
 
+#if (defined(CURL_FUZZER_EXPECT_OPENSSL) || \
+     defined(CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES)) && \
+    defined(CURL_FUZZER_EXPECT_GNUTLS)
+#error "A curl feature test must select exactly one expected TLS backend"
+#endif
+
 namespace {
 
 bool HasNamedFeature(const curl_version_info_data *info, const char *expected) {
@@ -22,6 +28,14 @@ bool HasNamedFeature(const curl_version_info_data *info, const char *expected) {
   }
   return false;
 }
+
+#if defined(CURL_FUZZER_EXPECT_OPENSSL) || \
+    defined(CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES) || \
+    defined(CURL_FUZZER_EXPECT_GNUTLS)
+bool HasPrefix(const char *value, const char *expected) {
+  return value && std::strncmp(value, expected, std::strlen(expected)) == 0;
+}
+#endif
 
 }  // namespace
 
@@ -43,15 +57,35 @@ int main() {
     std::fputs("libcurl was built with deprecated NTLM support\n", stderr);
     return 1;
   }
-#ifdef CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES
+#if defined(CURL_FUZZER_EXPECT_OPENSSL) || \
+    defined(CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES)
+  if (!HasPrefix(info->ssl_version, "OpenSSL/")) {
+    std::fputs("libcurl does not report OpenSSL as its TLS backend\n", stderr);
+    return 1;
+  }
+#endif
+#ifdef CURL_FUZZER_EXPECT_GNUTLS
+  if (!HasPrefix(info->ssl_version, "GnuTLS/")) {
+    std::fputs("libcurl does not report GnuTLS as its TLS backend\n", stderr);
+    return 1;
+  }
+#endif
+#if defined(CURL_FUZZER_EXPECT_HTTPSRR) || \
+    defined(CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES)
   if (!HasNamedFeature(info, "HTTPSRR")) {
     std::fputs("libcurl was built without HTTPS RR support\n", stderr);
     return 1;
   }
+#endif
+#if defined(CURL_FUZZER_EXPECT_ECH) || \
+    defined(CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES)
   if (!HasNamedFeature(info, "ECH")) {
     std::fputs("libcurl was built without ECH support\n", stderr);
     return 1;
   }
+#endif
+#if defined(CURL_FUZZER_EXPECT_HTTPSIG) || \
+    defined(CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES)
   if (!HasNamedFeature(info, "HTTPSIG")) {
     std::fputs("libcurl was built without HTTP Message Signatures support\n",
                stderr);

--- a/tests/mock_server_test.cc
+++ b/tests/mock_server_test.cc
@@ -611,21 +611,36 @@ void TestTlsAllKeyTypesReachCertificateInfo() {
   Expect(result.certificate_count == 4,
          "all-key-types TLS peer did not send every selected certificate");
   Expect(HasCertificateInfoPrefix(result, "RSA Public Key:"),
-         "RSA certificate did not reach ossl_certchain's key formatter");
+         "RSA certificate did not reach curl's certificate-info formatter");
 #ifndef OPENSSL_NO_DSA
   Expect(HasCertificateInfoPrefix(result, "dsa(p):"),
-         "DSA certificate did not reach ossl_certchain's key formatter");
+         "DSA certificate did not reach curl's certificate-info formatter");
 #endif
+#ifdef CURL_FUZZER_EXPECT_GNUTLS
+  // The shared ASN.1 parser recognizes X9.42 dhpublicnumber keys, whereas
+  // this PKCS#3 fixture deliberately uses dhKeyAgreement to exercise
+  // OpenSSL's EVP_PKEY_DH formatter in the default build.
+  Expect(HasCertificateInfoPrefix(result,
+                                  "Public Key Algorithm:1.2.840.113549.1.3.1"),
+         "PKCS#3 DH certificate did not reach curl's ASN.1 formatter");
+#else
   Expect(HasCertificateInfoPrefix(result, "dh(p):"),
          "DH certificate did not reach ossl_certchain's key formatter");
+#endif
   Expect(HasCertificateInfoPrefix(result, "Serial Number:-"),
-         "negative certificate serial did not reach ossl_certchain");
+         "negative certificate serial did not reach certificate info");
 }
 
 void TestTls12OptionsForceNegotiatedVersion() {
   Scenario scenario = MakeTlsScenario("tls12", "tls12");
   AddUintOption(&scenario, curl::fuzzer::proto::CURLOPT_SSLVERSION,
                 CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_TLSv1_2);
+#ifdef CURL_FUZZER_EXPECT_GNUTLS
+  // GnuTLS treats CURLOPT_SSL_CIPHER_LIST as its complete priority language;
+  // curves and signature algorithms are selected through the same expression.
+  AddStringOption(&scenario, curl::fuzzer::proto::CURLOPT_SSL_CIPHER_LIST,
+                  "NORMAL:-VERS-ALL:+VERS-TLS1.2");
+#else
   AddStringOption(&scenario, curl::fuzzer::proto::CURLOPT_SSL_CIPHER_LIST,
                   "ECDHE-ECDSA-AES128-GCM-SHA256");
   AddStringOption(&scenario, curl::fuzzer::proto::CURLOPT_SSL_EC_CURVES,
@@ -633,6 +648,7 @@ void TestTls12OptionsForceNegotiatedVersion() {
   AddStringOption(&scenario,
                   curl::fuzzer::proto::CURLOPT_SSL_SIGNATURE_ALGORITHMS,
                   "ecdsa_secp256r1_sha256");
+#endif
 
   const TlsTransferResult result = DriveTlsScenario(scenario);
   Expect(result.code == CURLE_OK && result.response == "tls12",
@@ -673,6 +689,15 @@ void TestTlsRedirectReusesSession() {
   AddUintOption(&scenario, curl::fuzzer::proto::CURLOPT_MAXREDIRS, 2);
   AddBoolOption(&scenario, curl::fuzzer::proto::CURLOPT_SSL_SESSIONID_CACHE,
                 true);
+#ifdef CURL_FUZZER_EXPECT_GNUTLS
+  // GnuTLS receives TLS 1.3 tickets after the handshake, while this bounded
+  // peer closes as soon as the scripted response is complete. Use TLS 1.2 so
+  // the second connection deterministically exercises its session cache.
+  AddUintOption(&scenario, curl::fuzzer::proto::CURLOPT_SSLVERSION,
+                CURL_SSLVERSION_TLSv1_2 | CURL_SSLVERSION_MAX_TLSv1_2);
+  AddStringOption(&scenario, curl::fuzzer::proto::CURLOPT_SSL_CIPHER_LIST,
+                  "NORMAL:-VERS-ALL:+VERS-TLS1.2");
+#endif
   scenario.mutable_connection()->set_initial_response(
       "HTTP/1.1 302 Found\r\nLocation: https://tls.test/final\r\nConnection: "
       "close\r\nContent-Length: 0\r\n\r\n");
@@ -711,7 +736,7 @@ void TestTlsWriteRetryKeepsItsOriginalBoundary() {
          "appending a response chunk corrupted an outstanding TLS write retry");
 }
 
-#ifndef OPENSSL_NO_ECH
+#if !defined(OPENSSL_NO_ECH) && !defined(CURL_FUZZER_EXPECT_GNUTLS)
 void TestTlsEchCompletesEncryptedClientHello() {
   Scenario scenario = MakeTlsScenario("ech-success", "ech");
   AddStringOption(
@@ -1068,7 +1093,7 @@ int main() {
   TestTlsPublicKeyPins();
   TestTlsRedirectReusesSession();
   TestTlsWriteRetryKeepsItsOriginalBoundary();
-#ifndef OPENSSL_NO_ECH
+#if !defined(OPENSSL_NO_ECH) && !defined(CURL_FUZZER_EXPECT_GNUTLS)
   TestTlsEchCompletesEncryptedClientHello();
 #endif
   TestH2ProxyCarriesAnHttpOriginResponse();

--- a/tests/test_compare_fuzzers.py
+++ b/tests/test_compare_fuzzers.py
@@ -288,6 +288,44 @@ def test_h2_proxy_lane_uses_only_its_frame_aware_corpus() -> None:
     assert "curl_fuzzer_proto_h2_proxy" not in module.HISTORICAL_PROTO_CORPUS_TARGETS
 
 
+def test_gnutls_https_lane_reuses_compatible_https_corpora(tmp_path: Path) -> None:
+    module = _load_module()
+    corpus_root = tmp_path / "corpora"
+    https_corpus = corpus_root / "curl_fuzzer_proto_https"
+    https_corpus.mkdir(parents=True)
+    (https_corpus / "seed").write_bytes(b"https")
+
+    baseline_dir = tmp_path / "bin"
+    baseline_dir.mkdir()
+    https_seed_archive = baseline_dir / "curl_fuzzer_proto_https_seed_corpus.zip"
+    https_seed_archive.write_bytes(b"seed archive")
+
+    public_root = tmp_path / "public"
+    gnutls_public = public_root / "curl_fuzzer_proto_https_gnutls"
+    https_public = public_root / "curl_fuzzer_proto_https"
+    historical_public = public_root / "curl_fuzzer_proto"
+    for directory in (gnutls_public, https_public, historical_public):
+        directory.mkdir(parents=True)
+        (directory / "input").write_bytes(directory.name.encode())
+
+    sources = module._corpus_sources(
+        "curl_fuzzer_proto_https_gnutls",
+        baseline_dir,
+        corpus_root,
+        public_root,
+        {},
+    )
+
+    assert "curl_fuzzer_proto_https_gnutls" in module.DEFAULT_TARGETS
+    assert sources == [
+        https_corpus,
+        https_seed_archive,
+        gnutls_public,
+        https_public,
+        historical_public,
+    ]
+
+
 def test_ftp_and_tftp_lanes_keep_legacy_speed_baselines() -> None:
     module = _load_module()
 

--- a/tests/test_fuzzer_entrypoints.py
+++ b/tests/test_fuzzer_entrypoints.py
@@ -27,6 +27,7 @@ PROTO_TARGET_PROFILES = {
     "curl_fuzzer_proto_http": "kFastHttp",
     "curl_fuzzer_proto_http_deep": "kDeepHttp",
     "curl_fuzzer_proto_https": "kFastHttps",
+    "curl_fuzzer_proto_https_gnutls": "kFastHttps",
     "curl_fuzzer_proto_h2_proxy": "kH2Proxy",
     "curl_fuzzer_proto_ws": "kFastWebSocket",
     "curl_fuzzer_proto_wss": "kFastSecureWebSocket",
@@ -39,9 +40,12 @@ PROTO_TARGET_PROFILES = {
 }
 
 
-def _packaged_targets() -> set[str]:
+def _packaged_targets(
+    *, architecture: str = "x86_64", sanitizer: str = "address"
+) -> set[str]:
     environment = os.environ.copy()
-    environment["ARCHITECTURE"] = "x86_64"
+    environment["ARCHITECTURE"] = architecture
+    environment["SANITIZER"] = sanitizer
     result = subprocess.run(
         [
             "bash",
@@ -56,6 +60,15 @@ def _packaged_targets() -> set[str]:
         env=environment,
     )
     return set(result.stdout.splitlines())
+
+
+def test_gnutls_target_is_limited_to_supported_builds() -> None:
+    """Keep packaging aligned with the CMake sanitizer/architecture gates."""
+    target = "curl_fuzzer_proto_https_gnutls"
+
+    assert target in _packaged_targets()
+    assert target not in _packaged_targets(sanitizer="memory")
+    assert target not in _packaged_targets(architecture="i386")
 
 
 def _checked_in_cpp_sources() -> list[Path]:

--- a/tests/test_tls_scenarios.py
+++ b/tests/test_tls_scenarios.py
@@ -73,6 +73,11 @@ def test_tls_seeds_retain_version_pin_and_session_correlations() -> None:
             "ECDHE-ECDSA-AES128-GCM-SHA256",
             "ecdsa_secp256r1_sha256",
         ),
+        "https_gnutls_tls12_priority.textproto": (
+            "CURLOPT_SSLVERSION uint_value: 393222",
+            "NORMAL:-VERS-ALL:+VERS-TLS1.2",
+            "gnutls-tls12",
+        ),
         "https_pinned_public_key.textproto": (
             "CURLOPT_PINNEDPUBLICKEY",
             "sha256//ohF20oHrdt/MM3YpyIewiTdtTbgZwq3qatd40TjMtYg=",
@@ -80,6 +85,7 @@ def test_tls_seeds_retain_version_pin_and_session_correlations() -> None:
         ),
         "https_session_redirect.textproto": (
             "CURLOPT_SSL_SESSIONID_CACHE bool_value: true",
+            "CURLOPT_SSLVERSION uint_value: 393222",
             "Connection: close",
             "subsequent_connections {",
         ),


### PR DESCRIPTION
Build a second static libcurl with GnuTLS and add a dedicated HTTPS fuzzer while retaining the OpenSSL-based mock server. Reuse the HTTPS corpus, add GnuTLS-specific TLS seeds, and update CI and cache plumbing.