### PR TITLE
fuzz: add HTTP/3 proto target with an ngtcp2 peer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,22 +422,27 @@ else()
     add_custom_target(openldap_external)
 endif()
 
-# Additional TLS backends are useful only for the 64-bit structured suite.
-# Keep them out of MSan until their complete crypto dependency stacks can be
-# built against an instrumented C library; this mirrors the existing OpenSSL
-# exclusion.
+# Additional TLS and HTTP/3 variants are useful only for the 64-bit structured
+# suite. Keep them out of MSan until their complete crypto dependency stacks
+# can be built against an instrumented C library; this mirrors the existing
+# OpenSSL exclusion.
 set(BUILD_GNUTLS_VARIANT FALSE)
 set(GNUTLS_EXTERNAL_DEP "")
 set(GNUTLS_CACHE_INSTALL_DIRS "")
 set(BUILD_MBEDTLS_VARIANT FALSE)
 set(MBEDTLS_EXTERNAL_DEP "")
 set(MBEDTLS_CACHE_INSTALL_DIRS "")
+set(BUILD_HTTP3_VARIANT FALSE)
+set(HTTP3_EXTERNAL_DEP "")
+set(HTTP3_CACHE_INSTALL_DIRS "")
 if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386" AND
    NOT "$ENV{SANITIZER}" STREQUAL "memory")
     set(BUILD_GNUTLS_VARIANT TRUE)
     include(${CMAKE_SOURCE_DIR}/cmake/GnuTLSDependencies.cmake)
     set(BUILD_MBEDTLS_VARIANT TRUE)
     include(${CMAKE_SOURCE_DIR}/cmake/MbedTLSDependencies.cmake)
+    set(BUILD_HTTP3_VARIANT TRUE)
+    include(${CMAKE_SOURCE_DIR}/cmake/Http3Dependencies.cmake)
 endif()
 
 # Group non-curl dependencies into a single target
@@ -452,6 +457,7 @@ add_custom_target(deps
         openldap_external
         ${GNUTLS_EXTERNAL_DEP}
         ${MBEDTLS_EXTERNAL_DEP}
+        ${HTTP3_EXTERNAL_DEP}
 )
 
 # Now for the main dependencies!
@@ -463,6 +469,7 @@ add_custom_target(deps
 set(CURL_INSTALL_DIR ${CMAKE_BINARY_DIR}/curl-install)
 set(CURL_GNUTLS_INSTALL_DIR ${CMAKE_BINARY_DIR}/curl-gnutls-install)
 set(CURL_MBEDTLS_INSTALL_DIR ${CMAKE_BINARY_DIR}/curl-mbedtls-install)
+set(CURL_HTTP3_INSTALL_DIR ${CMAKE_BINARY_DIR}/curl-http3-install)
 
 set(CURL_COMMON_CMAKE_ARGS
     -DCMAKE_INSTALL_LIBDIR=lib
@@ -592,6 +599,23 @@ if(BUILD_GNUTLS_VARIANT)
     )
 endif()
 
+if(BUILD_HTTP3_VARIANT)
+    set(CURL_HTTP3_CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${CURL_HTTP3_INSTALL_DIR}
+        ${CURL_COMMON_CMAKE_ARGS}
+        "-DCMAKE_C_FLAGS=${_CURL_BASE_C_FLAGS}"
+        "-DCMAKE_CXX_FLAGS=${_CURL_BASE_CXX_FLAGS}"
+        -DCURL_ENABLE_SSL=ON
+        -DCURL_USE_OPENSSL=ON
+        -DCURL_USE_GNUTLS=OFF
+        -DCURL_USE_MBEDTLS=OFF
+        -DOPENSSL_ROOT_DIR=${HTTP3_OPENSSL_INSTALL_DIR}
+        ${HTTP3_CURL_CMAKE_ARGS}
+        -DCURL_DISABLE_HTTPSIG=OFF
+        -DUSE_ECH=ON
+    )
+endif()
+
 function(curl_add_external_variant _target _install_dir)
     cmake_parse_arguments(VARIANT "" "" "CMAKE_ARGS;SOURCE_ARGS;DEPENDS" ${ARGN})
     ExternalProject_Add(${_target}
@@ -650,7 +674,7 @@ curl_add_external_variant(curl_external ${CURL_INSTALL_DIR}
     SOURCE_ARGS ${CURL_DEFAULT_SOURCE_ARGS}
     DEPENDS ${CURL_DEPS})
 
-if(BUILD_GNUTLS_VARIANT OR BUILD_MBEDTLS_VARIANT)
+if(BUILD_GNUTLS_VARIANT OR BUILD_MBEDTLS_VARIANT OR BUILD_HTTP3_VARIANT)
     if(NOT "$ENV{CURL_SOURCE_DIR}" STREQUAL "")
         set(CURL_TLS_VARIANT_SOURCE_ARGS
             SOURCE_DIR $ENV{CURL_SOURCE_DIR}
@@ -670,6 +694,19 @@ if(BUILD_GNUTLS_VARIANT OR BUILD_MBEDTLS_VARIANT)
         # Waiting for that project avoids racing a configure against its clone.
         set(CURL_TLS_VARIANT_SOURCE_DEP curl_external)
     endif()
+endif()
+
+if(BUILD_HTTP3_VARIANT)
+    set(CURL_HTTP3_DEPS
+        ${CURL_COMMON_DEPS}
+        libidn2_external
+        ${HTTP3_EXTERNAL_DEP}
+        ${CURL_TLS_VARIANT_SOURCE_DEP})
+    curl_add_external_variant(curl_http3_external
+        ${CURL_HTTP3_INSTALL_DIR}
+        CMAKE_ARGS ${CURL_HTTP3_CMAKE_ARGS}
+        SOURCE_ARGS ${CURL_TLS_VARIANT_SOURCE_ARGS}
+        DEPENDS ${CURL_HTTP3_DEPS})
 endif()
 
 if(BUILD_GNUTLS_VARIANT)
@@ -702,6 +739,8 @@ set(CURL_GNUTLS_STATIC_LIB
     ${CURL_GNUTLS_INSTALL_DIR}/lib/libcurl.a)
 set(CURL_MBEDTLS_STATIC_LIB
     ${CURL_MBEDTLS_INSTALL_DIR}/lib/libcurl.a)
+set(CURL_HTTP3_STATIC_LIB
+    ${CURL_HTTP3_INSTALL_DIR}/lib/libcurl.a)
 
 # Now it's time for the main targets!
 
@@ -718,6 +757,10 @@ set(CURL_GNUTLS_INCLUDE_DIRS
 set(CURL_MBEDTLS_INCLUDE_DIRS
     ${CURL_MBEDTLS_INSTALL_DIR}/include
     ${CURL_MBEDTLS_INSTALL_DIR}/utfuzzer
+)
+set(CURL_HTTP3_INCLUDE_DIRS
+    ${CURL_HTTP3_INSTALL_DIR}/include
+    ${CURL_HTTP3_INSTALL_DIR}/utfuzzer
 )
 
 # Fuzzing engine
@@ -780,6 +823,26 @@ if(TARGET openssl_external)
     target_link_libraries(curl_tls_mock_openssl INTERFACE
         ${OPENSSL_STATIC_LIB})
     add_dependencies(curl_tls_mock_openssl openssl_external)
+endif()
+
+if(BUILD_HTTP3_VARIANT)
+    add_library(curl_client_http3 INTERFACE)
+    target_include_directories(curl_client_http3 INTERFACE
+        ${CURL_HTTP3_INCLUDE_DIRS})
+    target_link_libraries(curl_client_http3 INTERFACE
+        ${CURL_HTTP3_STATIC_LIB}
+        curl_fuzzer::http3_dependencies
+        ${NGHTTP2_STATIC_LIB}
+        ${ZLIB_STATIC_LIB}
+        ${ZSTD_STATIC_LIB}
+        ${BROTLI_STATIC_LIBS}
+        ${LIBIDN2_STATIC_LIB}
+        ${OPENLDAP_STATIC_LIB_LDAP}
+        ${OPENLDAP_STATIC_LIB_LBER}
+        pthread
+        m)
+    add_dependencies(curl_client_http3
+        curl_http3_external ${CURL_HTTP3_DEPS})
 endif()
 
 if(BUILD_MBEDTLS_VARIANT)
@@ -928,6 +991,24 @@ if(BUILD_TESTING)
         add_test(NAME curl_mbedtls_features_test
             COMMAND curl_mbedtls_features_test)
         add_dependencies(fuzzer_unit_tests curl_mbedtls_features_test)
+    endif()
+
+    if(BUILD_HTTP3_VARIANT)
+        add_executable(curl_http3_features_test tests/curl_features_test.cc)
+        target_compile_features(curl_http3_features_test PRIVATE cxx_std_11)
+        target_compile_options(curl_http3_features_test PRIVATE ${COMMON_FLAGS})
+        target_compile_definitions(curl_http3_features_test PRIVATE
+            CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES
+            CURL_FUZZER_EXPECT_HTTP3)
+        target_link_libraries(curl_http3_features_test PRIVATE
+            curl_client_http3)
+        target_link_options(curl_http3_features_test PRIVATE
+            ${COVERAGE_LINK_FLAGS})
+        add_dependencies(curl_http3_features_test
+            curl_http3_external ${CURL_HTTP3_DEPS})
+        add_test(NAME curl_http3_features_test
+            COMMAND curl_http3_features_test)
+        add_dependencies(fuzzer_unit_tests curl_http3_features_test)
     endif()
 
     add_executable(legacy_protocol_allowlist_test
@@ -1166,6 +1247,8 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         COMMENT "protoc curl_fuzzer.proto"
         VERBATIM
     )
+    add_custom_target(curl_fuzzer_proto_generated
+        DEPENDS ${GEN_PB_CC} ${GEN_PB_H})
 
     # Write out a linker response file listing every .a the LPM install
     # produced — LPM's own libs (libprotobuf-mutator, libprotobuf-mutator-
@@ -1205,7 +1288,6 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         proto_fuzzer/api_lifecycle.cc
         proto_fuzzer/fuzzer_main.cc
         proto_fuzzer/ftp_mock_server.cc
-        proto_fuzzer/scenario_runner.cc
         proto_fuzzer/option_apply.cc
         proto_fuzzer/request_data.cc
         proto_fuzzer/mock_server.cc
@@ -1244,23 +1326,79 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     add_dependencies(curl_fuzzer_proto_runtime
         ${FUZZ_DEPS}
         libprotobuf_mutator_external
+        curl_fuzzer_proto_generated
         lpm_link_rsp
     )
+
+    # ScenarioRunner is compiled separately from the protocol implementation
+    # objects. The HTTP/3 lane can then select a runner that knows about its
+    # QUIC peer without pulling nghttp3/OpenSSL server references into every
+    # structured fuzzer executable.
+    add_library(curl_fuzzer_proto_runner OBJECT
+        proto_fuzzer/scenario_runner.cc)
+    target_compile_features(curl_fuzzer_proto_runner PRIVATE cxx_std_17)
+    target_compile_options(curl_fuzzer_proto_runner PRIVATE
+        ${COMMON_FLAGS} -DFUZZ_PROTOCOLS_HTTP)
+    target_include_directories(curl_fuzzer_proto_runner PRIVATE
+        ${CURL_INCLUDE_DIRS}
+        ${CMAKE_BINARY_DIR}
+        ${CMAKE_SOURCE_DIR}
+        ${LPM_PB_INCLUDE})
+    if(TARGET openssl_external)
+        target_compile_definitions(curl_fuzzer_proto_runner PRIVATE
+            PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
+        target_include_directories(curl_fuzzer_proto_runner PRIVATE
+            ${OPENSSL_INSTALL_DIR}/include)
+    endif()
+    add_dependencies(curl_fuzzer_proto_runner
+        ${FUZZ_DEPS}
+        curl_fuzzer_proto_generated
+        libprotobuf_mutator_external)
+
+    if(BUILD_HTTP3_VARIANT)
+        add_library(curl_fuzzer_proto_http3_runner OBJECT
+            proto_fuzzer/scenario_runner.cc
+            proto_fuzzer/http3_mock_server.cc)
+        target_compile_features(curl_fuzzer_proto_http3_runner PRIVATE
+            cxx_std_17)
+        target_compile_options(curl_fuzzer_proto_http3_runner PRIVATE
+            ${COMMON_FLAGS} -DFUZZ_PROTOCOLS_HTTP)
+        target_compile_definitions(curl_fuzzer_proto_http3_runner PRIVATE
+            PROTO_FUZZER_HAS_TLS_MOCK_SERVER
+            PROTO_FUZZER_HAS_HTTP3_MOCK_SERVER)
+        target_include_directories(curl_fuzzer_proto_http3_runner PRIVATE
+            ${CURL_HTTP3_INCLUDE_DIRS}
+            ${CMAKE_BINARY_DIR}
+            ${CMAKE_SOURCE_DIR}
+            ${LPM_PB_INCLUDE})
+        target_link_libraries(curl_fuzzer_proto_http3_runner PRIVATE
+            curl_fuzzer::http3_dependencies)
+        add_dependencies(curl_fuzzer_proto_http3_runner
+            curl_http3_external
+            ${CURL_HTTP3_DEPS}
+            curl_fuzzer_proto_generated
+            libprotobuf_mutator_external)
+    endif()
 
     # Build one compatibility binary plus fixed protocol/cost lanes. Each
     # entrypoint binds its TargetProfile in ordinary C++, keeping build-system
     # wiring independent of mutation and execution behaviour.
     function(curl_add_proto_fuzzer _name)
-        cmake_parse_arguments(PROTO "" "CLIENT" "INCLUDE_DIRS;DEPENDS" ${ARGN})
+        cmake_parse_arguments(PROTO "" "CLIENT;RUNNER"
+            "INCLUDE_DIRS;DEPENDS" ${ARGN})
         if(PROTO_UNPARSED_ARGUMENTS)
             message(FATAL_ERROR
                 "Unsupported arguments for ${_name}: ${PROTO_UNPARSED_ARGUMENTS}")
         endif()
         set(_curl_client curl_client_default)
+        set(_curl_runner curl_fuzzer_proto_runner)
         set(_curl_target_deps ${FUZZ_DEPS})
         set(_curl_include_dirs ${CURL_INCLUDE_DIRS})
         if(PROTO_CLIENT)
             set(_curl_client ${PROTO_CLIENT})
+        endif()
+        if(PROTO_RUNNER)
+            set(_curl_runner ${PROTO_RUNNER})
         endif()
         if(PROTO_DEPENDS)
             set(_curl_target_deps
@@ -1273,6 +1411,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         add_executable(${_name}
             fuzzer_entrypoints/${_name}.cc
             $<TARGET_OBJECTS:curl_fuzzer_proto_runtime>
+            $<TARGET_OBJECTS:${_curl_runner}>
         )
         target_compile_features(${_name} PRIVATE cxx_std_17)
         target_compile_options(${_name} PRIVATE
@@ -1304,6 +1443,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         add_dependencies(${_name}
             ${_curl_target_deps}
             curl_fuzzer_proto_runtime
+            ${_curl_runner}
             libprotobuf_mutator_external
             lpm_link_rsp
         )
@@ -1329,6 +1469,13 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
             INCLUDE_DIRS ${CURL_MBEDTLS_INCLUDE_DIRS}
             DEPENDS curl_mbedtls_external ${CURL_MBEDTLS_DEPS})
     endif()
+    if(BUILD_HTTP3_VARIANT)
+        curl_add_proto_fuzzer(curl_fuzzer_proto_http3
+            CLIENT curl_client_http3
+            RUNNER curl_fuzzer_proto_http3_runner
+            INCLUDE_DIRS ${CURL_HTTP3_INCLUDE_DIRS}
+            DEPENDS curl_http3_external ${CURL_HTTP3_DEPS})
+    endif()
     curl_add_proto_fuzzer(curl_fuzzer_proto_h2_proxy)
     curl_add_proto_fuzzer(curl_fuzzer_proto_ws)
     curl_add_proto_fuzzer(curl_fuzzer_proto_wss)
@@ -1347,6 +1494,8 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
          ${SCENARIO_SRC_DIR}/http/*.textproto)
     file(GLOB HTTPS_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
          ${SCENARIO_SRC_DIR}/https/*.textproto)
+    file(GLOB HTTP3_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
+         ${SCENARIO_SRC_DIR}/http3/*.textproto)
     file(GLOB H2_PROXY_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
          ${SCENARIO_SRC_DIR}/h2_proxy/*.textproto)
     file(GLOB WS_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
@@ -1496,6 +1645,8 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     add_proto_fuzzer_corpus(curl_fuzzer_proto_https_corpus
         curl_fuzzer_proto_https
         ${DEEP_HTTP_SCENARIO_TEXTPROTOS} ${HTTPS_SCENARIO_TEXTPROTOS})
+    add_proto_fuzzer_corpus(curl_fuzzer_proto_http3_corpus
+        curl_fuzzer_proto_http3 ${HTTP3_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_h2_proxy_corpus
         curl_fuzzer_proto_h2_proxy ${H2_PROXY_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_ws_corpus
@@ -1527,6 +1678,10 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     if(BUILD_MBEDTLS_VARIANT)
         add_dependencies(curl_fuzzer_proto_https_mbedtls
             curl_fuzzer_proto_https_corpus)
+    endif()
+    if(BUILD_HTTP3_VARIANT)
+        add_dependencies(curl_fuzzer_proto_http3
+            curl_fuzzer_proto_http3_corpus)
     endif()
     add_dependencies(curl_fuzzer_proto_h2_proxy
         curl_fuzzer_proto_h2_proxy_corpus)
@@ -1765,6 +1920,41 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         curl_add_proto_peer_test(ftp_mock_server_test
             tests/ftp_mock_server_test.cc
             proto_fuzzer/ftp_mock_server.cc)
+
+        if(BUILD_HTTP3_VARIANT)
+            add_executable(http3_mock_server_test
+                tests/http3_mock_server_test.cc
+                proto_fuzzer/http3_mock_server.cc
+                proto_fuzzer/mock_server.cc
+                proto_fuzzer/mock_server_base.cc
+                proto_fuzzer/multi_socket_driver.cc
+                proto_fuzzer/option_apply.cc
+                proto_fuzzer/request_data.cc
+                proto_fuzzer/ws_frame.cc
+                ${GEN_PB_CC})
+            target_compile_features(http3_mock_server_test PRIVATE cxx_std_17)
+            target_compile_options(http3_mock_server_test PRIVATE
+                ${COMMON_FLAGS})
+            target_include_directories(http3_mock_server_test PRIVATE
+                ${CURL_HTTP3_INCLUDE_DIRS}
+                ${CMAKE_BINARY_DIR}
+                ${CMAKE_SOURCE_DIR}
+                ${LPM_PB_INCLUDE})
+            target_link_libraries(http3_mock_server_test PRIVATE
+                curl_client_http3
+                "-Wl,@${LPM_LINK_RSP}")
+            target_link_options(http3_mock_server_test PRIVATE
+                ${COVERAGE_LINK_FLAGS})
+            add_dependencies(http3_mock_server_test
+                curl_http3_external
+                ${CURL_HTTP3_DEPS}
+                libprotobuf_mutator_external
+                lpm_link_rsp)
+            add_test(NAME http3_mock_server_test
+                COMMAND http3_mock_server_test)
+            set_tests_properties(http3_mock_server_test PROPERTIES TIMEOUT 10)
+            add_dependencies(fuzzer_unit_tests http3_mock_server_test)
+        endif()
     endif()
 
     # Documentation lint. `cmake --build build --target doxygen-check` runs
@@ -1862,6 +2052,11 @@ if(BUILD_MBEDTLS_VARIANT)
     list(APPEND CACHE_INSTALL_DIRS
         ${MBEDTLS_CACHE_INSTALL_DIRS}
         ${CURL_MBEDTLS_INSTALL_DIR})
+endif()
+if(BUILD_HTTP3_VARIANT)
+    list(APPEND CACHE_INSTALL_DIRS
+        ${HTTP3_CACHE_INSTALL_DIRS}
+        ${CURL_HTTP3_INSTALL_DIR})
 endif()
 if(BUILD_GDB)
     list(APPEND CACHE_INSTALL_DIRS ${GDB_INSTALL_DIR})

--- a/cmake/Http3Dependencies.cmake
+++ b/cmake/Http3Dependencies.cmake
@@ -1,0 +1,238 @@
+# Build the static HTTP/3 dependency stack used by curl's ngtcp2 backend.
+#
+# Curl's ngtcp2 integration needs libngtcp2, its OpenSSL crypto adapter, and
+# libnghttp3. The mock peer also uses ngtcp2's OpenSSL crypto adapter, so the
+# project's shared OpenSSL build can retain its normal unsafe TLS-fuzzing
+# behavior without exercising OpenSSL's incompatible native-QUIC shortcuts.
+# ngtcp2 and nghttp3 are configured library-only to keep OSS-Fuzz builds and
+# cached install prefixes small.
+
+include_guard(GLOBAL)
+include(ExternalProject)
+
+if(NOT UNIX)
+    message(FATAL_ERROR
+        "The hermetic HTTP/3 dependency stack currently supports Unix hosts only")
+endif()
+
+if(NOT DEFINED OPENSSL_VERSION OR OPENSSL_VERSION VERSION_LESS 3.5.0)
+    message(FATAL_ERROR
+        "The ngtcp2 OpenSSL backend requires OpenSSL 3.5.0 or newer")
+endif()
+if(NOT DEFINED OPENSSL_INSTALL_DIR OR NOT TARGET openssl_external)
+    message(FATAL_ERROR
+        "Http3Dependencies.cmake requires the shared OpenSSL dependency")
+endif()
+
+# Keep the marker compatible with scripts/trim_cache.sh. The top-level project
+# owns this recipe name; provide the same default when this module is exercised
+# by a small standalone configure project.
+if(NOT DEFINED MINIMAL_INSTALL_RECIPE)
+    set(MINIMAL_INSTALL_RECIPE minimal-install-v1)
+endif()
+if(NOT DEFINED MINIMAL_INSTALL_STAMP_NAME)
+    set(MINIMAL_INSTALL_STAMP_NAME
+        .curl-fuzzer-${MINIMAL_INSTALL_RECIPE})
+endif()
+
+set(HTTP3_OPENSSL_INSTALL_DIR ${OPENSSL_INSTALL_DIR})
+set(HTTP3_OPENSSL_INCLUDE_DIR ${HTTP3_OPENSSL_INSTALL_DIR}/include)
+set(HTTP3_OPENSSL_SSL_STATIC_LIB
+    ${HTTP3_OPENSSL_INSTALL_DIR}/lib/libssl.a)
+set(HTTP3_OPENSSL_CRYPTO_STATIC_LIB
+    ${HTTP3_OPENSSL_INSTALL_DIR}/lib/libcrypto.a)
+set(HTTP3_OPENSSL_STATIC_LIBS
+    ${HTTP3_OPENSSL_SSL_STATIC_LIB}
+    ${HTTP3_OPENSSL_CRYPTO_STATIC_LIB})
+set(HTTP3_OPENSSL_DEP openssl_external)
+
+# renovate: datasource=github-releases depName=ngtcp2/nghttp3
+set(HTTP3_NGHTTP3_VERSION 1.18.0)
+set(HTTP3_NGHTTP3_INSTALL_DIR
+    ${CMAKE_BINARY_DIR}/nghttp3-${HTTP3_NGHTTP3_VERSION}-install)
+set(HTTP3_NGHTTP3_INCLUDE_DIR ${HTTP3_NGHTTP3_INSTALL_DIR}/include)
+set(HTTP3_NGHTTP3_STATIC_LIB
+    ${HTTP3_NGHTTP3_INSTALL_DIR}/lib/libnghttp3.a)
+set(HTTP3_NGHTTP3_INSTALL_STAMP
+    ${HTTP3_NGHTTP3_INSTALL_DIR}/${MINIMAL_INSTALL_STAMP_NAME})
+
+if(NOT EXISTS ${HTTP3_NGHTTP3_INSTALL_STAMP} OR
+   NOT EXISTS ${HTTP3_NGHTTP3_STATIC_LIB})
+    ExternalProject_Add(http3_nghttp3_external
+        URL
+            https://github.com/ngtcp2/nghttp3/releases/download/v${HTTP3_NGHTTP3_VERSION}/nghttp3-${HTTP3_NGHTTP3_VERSION}.tar.xz
+        PREFIX
+            ${CMAKE_BINARY_DIR}/nghttp3-${HTTP3_NGHTTP3_VERSION}-${MINIMAL_INSTALL_RECIPE}
+        CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX=${HTTP3_NGHTTP3_INSTALL_DIR}
+            -DCMAKE_INSTALL_LIBDIR=lib
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            "-DCMAKE_C_FLAGS=$ENV{CFLAGS}"
+            "-DCMAKE_EXE_LINKER_FLAGS=$ENV{LDFLAGS}"
+            -DENABLE_LIB_ONLY=ON
+            -DENABLE_STATIC_LIB=ON
+            -DENABLE_SHARED_LIB=OFF
+            -DBUILD_TESTING=OFF
+            -DENABLE_WERROR=OFF
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} --build <BINARY_DIR> --target nghttp3_static
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E remove_directory
+                ${HTTP3_NGHTTP3_INSTALL_DIR}
+        COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR>
+        COMMAND ${CMAKE_COMMAND} -E touch ${HTTP3_NGHTTP3_INSTALL_STAMP}
+        BUILD_BYPRODUCTS
+            ${HTTP3_NGHTTP3_STATIC_LIB}
+            ${HTTP3_NGHTTP3_INSTALL_STAMP}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        DOWNLOAD_NO_PROGRESS 1
+    )
+else()
+    message(STATUS
+        "nghttp3 already installed at ${HTTP3_NGHTTP3_INSTALL_DIR}, skipping build")
+    add_custom_target(http3_nghttp3_external)
+endif()
+
+# renovate: datasource=github-releases depName=ngtcp2/ngtcp2
+set(HTTP3_NGTCP2_VERSION 1.25.0)
+set(HTTP3_NGTCP2_INSTALL_DIR
+    ${CMAKE_BINARY_DIR}/ngtcp2-${HTTP3_NGTCP2_VERSION}-install)
+set(HTTP3_NGTCP2_INCLUDE_DIR ${HTTP3_NGTCP2_INSTALL_DIR}/include)
+set(HTTP3_NGTCP2_STATIC_LIB
+    ${HTTP3_NGTCP2_INSTALL_DIR}/lib/libngtcp2.a)
+set(HTTP3_NGTCP2_CRYPTO_OSSL_STATIC_LIB
+    ${HTTP3_NGTCP2_INSTALL_DIR}/lib/libngtcp2_crypto_ossl.a)
+set(HTTP3_NGTCP2_INSTALL_STAMP
+    ${HTTP3_NGTCP2_INSTALL_DIR}/${MINIMAL_INSTALL_STAMP_NAME})
+
+if(NOT EXISTS ${HTTP3_NGTCP2_INSTALL_STAMP} OR
+   NOT EXISTS ${HTTP3_NGTCP2_STATIC_LIB} OR
+   NOT EXISTS ${HTTP3_NGTCP2_CRYPTO_OSSL_STATIC_LIB})
+    ExternalProject_Add(http3_ngtcp2_external
+        URL
+            https://github.com/ngtcp2/ngtcp2/releases/download/v${HTTP3_NGTCP2_VERSION}/ngtcp2-${HTTP3_NGTCP2_VERSION}.tar.xz
+        PREFIX
+            ${CMAKE_BINARY_DIR}/ngtcp2-${HTTP3_NGTCP2_VERSION}-${MINIMAL_INSTALL_RECIPE}
+        CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX=${HTTP3_NGTCP2_INSTALL_DIR}
+            -DCMAKE_INSTALL_LIBDIR=lib
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            "-DCMAKE_C_FLAGS=$ENV{CFLAGS}"
+            "-DCMAKE_EXE_LINKER_FLAGS=$ENV{LDFLAGS}"
+            -DCMAKE_PREFIX_PATH=${HTTP3_OPENSSL_INSTALL_DIR}
+            -DOPENSSL_ROOT_DIR=${HTTP3_OPENSSL_INSTALL_DIR}
+            -DOPENSSL_INCLUDE_DIR=${HTTP3_OPENSSL_INCLUDE_DIR}
+            -DOPENSSL_SSL_LIBRARY=${HTTP3_OPENSSL_SSL_STATIC_LIB}
+            -DOPENSSL_CRYPTO_LIBRARY=${HTTP3_OPENSSL_CRYPTO_STATIC_LIB}
+            -DOPENSSL_USE_STATIC_LIBS=ON
+            -DENABLE_LIB_ONLY=ON
+            -DENABLE_STATIC_LIB=ON
+            -DENABLE_SHARED_LIB=OFF
+            -DBUILD_TESTING=OFF
+            -DENABLE_WERROR=OFF
+            -DENABLE_OPENSSL=ON
+            -DENABLE_BORINGSSL=OFF
+            -DENABLE_GNUTLS=OFF
+            -DENABLE_PICOTLS=OFF
+            -DENABLE_WOLFSSL=OFF
+            -DENABLE_JEMALLOC=OFF
+            # ngtcp2's single OpenSSL switch selects between QuicTLS and the
+            # native OpenSSL 3.5+ adapter by probing these two symbols. An
+            # OSS-Fuzz-instrumented static libssl cannot be try-linked without
+            # the sanitizer runtime, so tell CMake the result guaranteed by
+            # the OpenSSL version check above instead of accepting a false
+            # negative and rejecting the backend.
+            -DHAVE_SSL_PROVIDE_QUIC_DATA=OFF
+            -DHAVE_SSL_SET_QUIC_TLS_CBS=ON
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} --build <BINARY_DIR>
+                --target ngtcp2_static ngtcp2_crypto_ossl_static
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E remove_directory
+                ${HTTP3_NGTCP2_INSTALL_DIR}
+        COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR>
+        COMMAND ${CMAKE_COMMAND} -E touch ${HTTP3_NGTCP2_INSTALL_STAMP}
+        DEPENDS ${HTTP3_OPENSSL_DEP}
+        BUILD_BYPRODUCTS
+            ${HTTP3_NGTCP2_STATIC_LIB}
+            ${HTTP3_NGTCP2_CRYPTO_OSSL_STATIC_LIB}
+            ${HTTP3_NGTCP2_INSTALL_STAMP}
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+        DOWNLOAD_NO_PROGRESS 1
+    )
+else()
+    message(STATUS
+        "ngtcp2 already installed at ${HTTP3_NGTCP2_INSTALL_DIR}, skipping build")
+    add_custom_target(http3_ngtcp2_external)
+    add_dependencies(http3_ngtcp2_external ${HTTP3_OPENSSL_DEP})
+endif()
+
+add_custom_target(http3_dependencies
+    DEPENDS
+        ${HTTP3_OPENSSL_DEP}
+        http3_nghttp3_external
+        http3_ngtcp2_external)
+
+# Put dependent archives first for a conventional one-pass static link:
+# libngtcp2_crypto_ossl calls libngtcp2 and then the shared OpenSSL stack.
+set(HTTP3_STATIC_LIBS
+    ${HTTP3_NGHTTP3_STATIC_LIB}
+    ${HTTP3_NGTCP2_CRYPTO_OSSL_STATIC_LIB}
+    ${HTTP3_NGTCP2_STATIC_LIB}
+)
+set(HTTP3_SYSTEM_LIBS ${CMAKE_DL_LIBS})
+set(HTTP3_EXTERNAL_DEP http3_dependencies)
+set(HTTP3_EXTERNAL_DEPS
+    ${HTTP3_OPENSSL_DEP}
+    http3_nghttp3_external
+    http3_ngtcp2_external
+)
+set(HTTP3_CACHE_INSTALL_DIRS
+    ${HTTP3_NGHTTP3_INSTALL_DIR}
+    ${HTTP3_NGTCP2_INSTALL_DIR}
+)
+
+# Arguments consumed by the dedicated curl HTTP/3 variant. Direct paths keep
+# detection hermetic even though the minimal OpenSSL install intentionally
+# removes pkg-config metadata.
+set(HTTP3_CURL_CMAKE_ARGS
+    -DUSE_NGTCP2=ON
+    -DUSE_QUICHE=OFF
+    -DOPENSSL_ROOT_DIR=${HTTP3_OPENSSL_INSTALL_DIR}
+    -DOPENSSL_USE_STATIC_LIBS=ON
+    -DOPENSSL_INCLUDE_DIR=${HTTP3_OPENSSL_INCLUDE_DIR}
+    -DOPENSSL_SSL_LIBRARY=${HTTP3_OPENSSL_SSL_STATIC_LIB}
+    -DOPENSSL_CRYPTO_LIBRARY=${HTTP3_OPENSSL_CRYPTO_STATIC_LIB}
+    # Curl repeats the same native-QUIC symbol probe while selecting the
+    # ngtcp2 "ossl" component. Avoid the same sanitizer try-link failure.
+    -DHAVE_SSL_SET_QUIC_TLS_CBS=ON
+    -DNGHTTP3_USE_STATIC_LIBS=ON
+    -DNGHTTP3_INCLUDE_DIR=${HTTP3_NGHTTP3_INCLUDE_DIR}
+    -DNGHTTP3_LIBRARY=${HTTP3_NGHTTP3_STATIC_LIB}
+    -DNGTCP2_USE_STATIC_LIBS=ON
+    -DNGTCP2_INCLUDE_DIR=${HTTP3_NGTCP2_INCLUDE_DIR}
+    -DNGTCP2_LIBRARY=${HTTP3_NGTCP2_STATIC_LIB}
+    -DNGTCP2_CRYPTO_OSSL_LIBRARY=${HTTP3_NGTCP2_CRYPTO_OSSL_STATIC_LIB}
+)
+
+# CMake validates interface include paths while generating, before the
+# ExternalProjects have installed them. Create only the empty roots here; the
+# dependency chain populates them before any consumer is compiled.
+file(MAKE_DIRECTORY
+    ${HTTP3_OPENSSL_INCLUDE_DIR}
+    ${HTTP3_NGHTTP3_INCLUDE_DIR}
+    ${HTTP3_NGTCP2_INCLUDE_DIR})
+add_library(curl_fuzzer_http3_dependencies INTERFACE)
+target_include_directories(curl_fuzzer_http3_dependencies INTERFACE
+    ${HTTP3_NGHTTP3_INCLUDE_DIR}
+    ${HTTP3_NGTCP2_INCLUDE_DIR}
+    ${HTTP3_OPENSSL_INCLUDE_DIR})
+target_link_libraries(curl_fuzzer_http3_dependencies INTERFACE
+    ${HTTP3_STATIC_LIBS}
+    ${HTTP3_OPENSSL_STATIC_LIBS}
+    ${HTTP3_SYSTEM_LIBS})
+add_dependencies(curl_fuzzer_http3_dependencies http3_dependencies)
+add_library(curl_fuzzer::http3_dependencies ALIAS
+    curl_fuzzer_http3_dependencies)

--- a/fuzzer_entrypoints/curl_fuzzer_proto_http3.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_http3.cc
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include "proto_fuzzer/fuzzer_main.h"
+
+namespace {
+
+// Keep the HTTP/3 identity in a thin same-named entrypoint. The shared proto
+// runtime applies its fixed mutation policy and dispatches the H3 run mode.
+using Fuzzer = proto_fuzzer::ProtoFuzzerEntrypoint<
+    proto_fuzzer::TargetProfile::kFastHttp3>;
+
+} // namespace
+
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return Fuzzer::CustomMutator(data, size, max_size, seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return Fuzzer::CustomCrossOver(data1, size1, data2, size2, out, max_out_size,
+                                 seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
+                                      std::size_t size) {
+  return Fuzzer::TestOneInput(data, size);
+}

--- a/ossconfig/curl_fuzzer_proto_http3.options
+++ b/ossconfig/curl_fuzzer_proto_http3.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32768

--- a/ossfuzz.sh
+++ b/ossfuzz.sh
@@ -60,7 +60,8 @@ if [[ "${CIFUZZ:-}" == "True" || -n "${REPLAY_ENABLED:-}" ]]; then
   rm -f "${BUILD_DIR}/curl-install/lib/libcurl.a"
   rm -f "${BUILD_DIR}/curl-gnutls-install/lib/libcurl.a"
   rm -f "${BUILD_DIR}/curl-mbedtls-install/lib/libcurl.a"
-  for CURL_VARIANT in curl_external curl_gnutls_external curl_mbedtls_external; do
+  rm -f "${BUILD_DIR}/curl-http3-install/lib/libcurl.a"
+  for CURL_VARIANT in curl_external curl_gnutls_external curl_mbedtls_external curl_http3_external; do
     rm -f "${BUILD_DIR}/${CURL_VARIANT}-prefix/src/${CURL_VARIANT}-stamp/${CURL_VARIANT}-"{configure,build,install,done}
   done
 fi

--- a/proto_fuzzer/http3_mock_server.cc
+++ b/proto_fuzzer/http3_mock_server.cc
@@ -1,0 +1,1625 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+/// @file
+/// @brief ngtcp2 QUIC transport and nghttp3 peer implementation.
+
+#include "proto_fuzzer/http3_mock_server.h"
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <nghttp3/nghttp3.h>
+#include <ngtcp2/ngtcp2.h>
+#include <ngtcp2/ngtcp2_crypto.h>
+#include <ngtcp2/ngtcp2_crypto_ossl.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/ssl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <climits>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "proto_fuzzer/multi_socket_driver.h"
+#include "proto_fuzzer/scenario_limits.h"
+#include "proto_fuzzer/tls_test_credentials.h"
+
+namespace proto_fuzzer {
+
+namespace {
+
+constexpr std::int64_t kNoStreamId = -1;
+constexpr std::size_t kMaxDatagramsPerTurn = 64;
+constexpr std::size_t kServerConnectionIdBytes = 18;
+constexpr std::size_t kReceiveBufferBytes = 64 * 1024;
+// One request plus the six HTTP/3 critical streams leave room for every
+// bounded action to create a fresh raw unidirectional stream.
+constexpr std::size_t kMaxStreams = scenario_limits::kMaxHttp3Actions + 8;
+constexpr std::size_t kMaxWritesPerTurn = 64;
+constexpr std::size_t kMaxPendingPlaintextBytes = 64 * 1024;
+constexpr int kHttp3IdleIterations = 32;
+// QUIC's first two bits select one of these wire widths. The remaining bits
+// encode the integer itself.
+constexpr std::array<std::size_t, 4> kQuicVarintByteWidths = {1, 2, 4, 8};
+constexpr unsigned int kQuicVarintTagBits = 2;
+constexpr unsigned int kQuicVarintTagShift = CHAR_BIT - kQuicVarintTagBits;
+static_assert(CHAR_BIT == 8, "QUIC varints require 8-bit bytes");
+
+enum StreamRoleIndex : std::size_t {
+  kResponseStream = 0,
+  kControlStream = 1,
+  kQpackEncoderStream = 2,
+  kQpackDecoderStream = 3,
+  kStreamRoleCount = 4,
+};
+
+/// Keep server-side OpenSSL failures from changing error classification in
+/// curl's OpenSSL client, which executes on the same thread.
+class OpenSslErrorQueueGuard {
+ public:
+  OpenSslErrorQueueGuard() { ERR_clear_error(); }
+  ~OpenSslErrorQueueGuard() { ERR_clear_error(); }
+
+  OpenSslErrorQueueGuard(const OpenSslErrorQueueGuard&) = delete;
+  OpenSslErrorQueueGuard& operator=(const OpenSslErrorQueueGuard&) = delete;
+};
+
+/// Configure callback-created descriptors explicitly: curl's requested
+/// SOCK_NONBLOCK and SOCK_CLOEXEC flags do not constrain an application fd.
+bool ConfigureSocket(int fd) {
+  if (fd < 0) {
+    return false;
+  }
+  const int descriptor_flags = ::fcntl(fd, F_GETFD, 0);
+  if (descriptor_flags < 0 || ::fcntl(fd, F_SETFD, descriptor_flags | FD_CLOEXEC) < 0) {
+    return false;
+  }
+  const int status_flags = ::fcntl(fd, F_GETFL, 0);
+  return status_flags >= 0 && ::fcntl(fd, F_SETFL, status_flags | O_NONBLOCK) == 0;
+}
+
+/// Bind one private IPv4 UDP endpoint to an ephemeral loopback port.
+int OpenLoopbackSocket(struct sockaddr_in* bound_address) {
+  if (bound_address == nullptr) {
+    return -1;
+  }
+
+  const int fd = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (fd < 0 || !ConfigureSocket(fd)) {
+    if (fd >= 0) {
+      (void)::close(fd);
+    }
+    return -1;
+  }
+
+  struct sockaddr_in requested = {};
+  requested.sin_family = AF_INET;
+  requested.sin_port = htons(0);
+  requested.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  if (::bind(fd, reinterpret_cast<const struct sockaddr*>(&requested), sizeof(requested)) != 0) {
+    (void)::close(fd);
+    return -1;
+  }
+
+  socklen_t length = sizeof(*bound_address);
+  std::memset(bound_address, 0, sizeof(*bound_address));
+  if (::getsockname(fd, reinterpret_cast<struct sockaddr*>(bound_address), &length) != 0 ||
+      length != sizeof(*bound_address) || bound_address->sin_family != AF_INET) {
+    (void)::close(fd);
+    return -1;
+  }
+  return fd;
+}
+
+/// Replace all destination metadata curl can retain with the private listener.
+bool RewriteDestination(struct curl_sockaddr* address, const struct sockaddr_in& destination) {
+  if (address == nullptr || sizeof(destination) > sizeof(address->addr)) {
+    return false;
+  }
+  address->family = AF_INET;
+  address->socktype = SOCK_DGRAM;
+  address->protocol = IPPROTO_UDP;
+  address->addrlen = sizeof(destination);
+  std::memset(&address->addr, 0, sizeof(address->addr));
+  std::memcpy(&address->addr, &destination, sizeof(destination));
+  return true;
+}
+
+/// Select only the final RFC HTTP/3 ALPN identifier.
+int SelectHttp3Alpn(SSL* /*ssl*/, const unsigned char** selected, unsigned char* selected_length,
+                    const unsigned char* client_protocols, unsigned int client_protocols_length, void* /*userdata*/) {
+  static constexpr unsigned char server_protocols[] = {2, 'h', '3'};
+  unsigned char* match = nullptr;
+  unsigned char match_length = 0;
+  const int result = SSL_select_next_proto(&match, &match_length, server_protocols, sizeof(server_protocols),
+                                           client_protocols, client_protocols_length);
+  if (result != OPENSSL_NPN_NEGOTIATED) {
+    return SSL_TLSEXT_ERR_ALERT_FATAL;
+  }
+  *selected = match;
+  *selected_length = match_length;
+  return SSL_TLSEXT_ERR_OK;
+}
+
+/// Append one profile-selected certificate without transferring a malformed
+/// object into the context on parse failure.
+bool AddExtraChainCertificate(SSL_CTX* context, const char* certificate_pem) {
+  BIO* certificate_bio = BIO_new_mem_buf(certificate_pem, -1);
+  if (certificate_bio == nullptr) {
+    return false;
+  }
+  X509* certificate = PEM_read_bio_X509(certificate_bio, nullptr, nullptr, nullptr);
+  BIO_free(certificate_bio);
+  if (certificate == nullptr) {
+    return false;
+  }
+  if (SSL_CTX_add_extra_chain_cert(context, certificate) != 1) {
+    X509_free(certificate);
+    return false;
+  }
+  return true;
+}
+
+/// Parse the checked-in key and profile-selected chain entirely in memory.
+bool LoadCredentials(SSL_CTX* context, curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain) {
+  BIO* certificate_bio = BIO_new_mem_buf(tls_test_credentials::kCertificatePem, -1);
+  BIO* key_bio = BIO_new_mem_buf(tls_test_credentials::kPrivateKeyPem, -1);
+  if (certificate_bio == nullptr || key_bio == nullptr) {
+    BIO_free(certificate_bio);
+    BIO_free(key_bio);
+    return false;
+  }
+
+  X509* certificate = PEM_read_bio_X509(certificate_bio, nullptr, nullptr, nullptr);
+  EVP_PKEY* key = PEM_read_bio_PrivateKey(key_bio, nullptr, nullptr, nullptr);
+  BIO_free(certificate_bio);
+  BIO_free(key_bio);
+  if (certificate == nullptr || key == nullptr) {
+    X509_free(certificate);
+    EVP_PKEY_free(key);
+    return false;
+  }
+
+  const bool loaded = SSL_CTX_use_certificate(context, certificate) == 1 && SSL_CTX_use_PrivateKey(context, key) == 1 &&
+                      SSL_CTX_check_private_key(context) == 1;
+  X509_free(certificate);
+  EVP_PKEY_free(key);
+  if (!loaded) {
+    return false;
+  }
+
+  if (certificate_chain == curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES) {
+    return AddExtraChainCertificate(context, tls_test_credentials::kRsaCertificatePem) &&
+           AddExtraChainCertificate(context, tls_test_credentials::kDsaCertificatePem) &&
+           AddExtraChainCertificate(context, tls_test_credentials::kDhCertificatePem);
+  }
+  return true;
+}
+
+/// Create a TLS 1.3 context for ngtcp2's OpenSSL crypto adapter.
+SSL_CTX* CreateTlsContext(curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain) {
+  OpenSslErrorQueueGuard error_guard;
+  SSL_CTX* context = SSL_CTX_new(TLS_server_method());
+  if (context == nullptr || !LoadCredentials(context, certificate_chain)) {
+    SSL_CTX_free(context);
+    return nullptr;
+  }
+
+  if (SSL_CTX_set_min_proto_version(context, TLS1_3_VERSION) != 1 ||
+      SSL_CTX_set_max_proto_version(context, TLS1_3_VERSION) != 1) {
+    SSL_CTX_free(context);
+    return nullptr;
+  }
+  (void)SSL_CTX_set_options(context, SSL_OP_NO_COMPRESSION);
+  SSL_CTX_set_alpn_select_cb(context, &SelectHttp3Alpn, nullptr);
+  return context;
+}
+
+/// Encode one QUIC variable-length integer in its shortest representation.
+void AppendQuicVarint(std::string* output, std::uint64_t value) {
+  value &= scenario_limits::kMaxQuicVarint;
+  for (std::size_t encoding = 0; encoding < kQuicVarintByteWidths.size(); ++encoding) {
+    const std::size_t byte_width = kQuicVarintByteWidths[encoding];
+    const unsigned int value_bits = static_cast<unsigned int>(byte_width * CHAR_BIT - kQuicVarintTagBits);
+    if (value >= (std::uint64_t{1} << value_bits)) {
+      continue;
+    }
+
+    for (std::size_t byte = byte_width; byte != 0; --byte) {
+      const unsigned int shift = static_cast<unsigned int>((byte - 1) * CHAR_BIT);
+      unsigned char encoded_byte = static_cast<unsigned char>(value >> shift);
+      if (byte == byte_width) {
+        encoded_byte |= static_cast<unsigned char>(encoding << kQuicVarintTagShift);
+      }
+      output->push_back(static_cast<char>(encoded_byte));
+    }
+    return;
+  }
+}
+
+/// Normalize a header name again at the runtime boundary. Fixed H3 targets
+/// already run the postprocessor; this also keeps direct unit-test scenarios
+/// safe to pass to nghttp3.
+std::string NormalizeHeaderName(const std::string& source) {
+  std::string result = source.substr(0, scenario_limits::kMaxHttp3HeaderNameBytes);
+  if (result.empty()) {
+    return "x-fuzz";
+  }
+  for (char& byte : result) {
+    const unsigned char value = static_cast<unsigned char>(byte);
+    const bool lower = value >= 'a' && value <= 'z';
+    const bool upper = value >= 'A' && value <= 'Z';
+    const bool digit = value >= '0' && value <= '9';
+    const bool punctuation = value == '!' || value == '#' || value == '$' || value == '%' || value == '&' ||
+                             value == '\'' || value == '*' || value == '+' || value == '-' || value == '.' ||
+                             value == '^' || value == '_' || value == '`' || value == '|' || value == '~';
+    if (upper) {
+      byte = static_cast<char>(value - 'A' + 'a');
+    } else if (!lower && !digit && !punctuation) {
+      byte = '-';
+    }
+  }
+  return result;
+}
+
+/// Remove control bytes that would make a structured field value malformed.
+std::string NormalizeHeaderValue(const std::string& source) {
+  std::string result = source.substr(0, scenario_limits::kMaxHttp3HeaderValueBytes);
+  for (char& byte : result) {
+    const unsigned char value = static_cast<unsigned char>(byte);
+    if ((value < 0x20U && value != '\t') || value == 0x7fU) {
+      byte = ' ';
+    }
+  }
+  return result;
+}
+
+/// Return ngtcp2's nanosecond-resolution monotonic timestamp.
+ngtcp2_tstamp QuicNow() {
+  const auto now = std::chrono::steady_clock::now().time_since_epoch();
+  return static_cast<ngtcp2_tstamp>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+}
+
+}  // namespace
+
+/// Private transport and HTTP/3 state. Keeping ngtcp2, OpenSSL, and nghttp3
+/// out of the public header lets other proto targets compile without their
+/// include trees.
+class Http3MockServerImpl {
+ public:
+  explicit Http3MockServerImpl(curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain)
+      : context_(CreateTlsContext(certificate_chain)), crypto_connection_ref_{&GetQuicConnection, this} {
+    role_stream_ids_.fill(kNoStreamId);
+    streams_.reserve(kMaxStreams);
+    retained_writes_.reserve(kMaxWritesPerTurn);
+  }
+
+  ~Http3MockServerImpl() {
+    ResetPeer();
+    OpenSslErrorQueueGuard error_guard;
+    SSL_CTX_free(context_);
+  }
+
+  Http3MockServerImpl(const Http3MockServerImpl&) = delete;
+  Http3MockServerImpl& operator=(const Http3MockServerImpl&) = delete;
+
+  curl_socket_t OpenSocket(curlsocktype purpose, struct curl_sockaddr* address) {
+    if (purpose != CURLSOCKTYPE_IPCXN || address == nullptr || socket_opened_ || context_ == nullptr) {
+      return CURL_SOCKET_BAD;
+    }
+    socket_opened_ = true;
+
+    struct sockaddr_in listener_address = {};
+    server_fd_ = OpenLoopbackSocket(&listener_address);
+    if (server_fd_ < 0 || !RewriteDestination(address, listener_address)) {
+      ResetPeer();
+      return CURL_SOCKET_BAD;
+    }
+    server_port_ = ntohs(listener_address.sin_port);
+    local_address_ = listener_address;
+
+    const int client_fd = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (client_fd < 0 || !ConfigureSocket(client_fd)) {
+      if (client_fd >= 0) {
+        (void)::close(client_fd);
+      }
+      ResetPeer();
+      return CURL_SOCKET_BAD;
+    }
+    return static_cast<curl_socket_t>(client_fd);
+  }
+
+  void BeginScenario(const curl::fuzzer::proto::Scenario& scenario) {
+    ResetPeer();
+    scenario_ = &scenario;
+    default_response_.Clear();
+    default_response_.set_status_code(200);
+    default_response_.set_finish_stream(true);
+  }
+
+  std::size_t DrivePeerTurn() {
+    if (server_fd_ < 0 || transport_failed_) {
+      return 0;
+    }
+
+    OpenSslErrorQueueGuard error_guard;
+    std::size_t progress = HandleExpiry();
+    if (transport_failed_) {
+      return progress;
+    }
+    progress += ReadDatagrams();
+    if (quic_connection_ == nullptr || transport_failed_) {
+      return progress;
+    }
+
+    if (handshake_complete_ && !close_requested_ && !close_sent_) {
+      progress += CreateServerStreams();
+      progress += DriveApplicationOutput();
+    }
+    progress += FlushTransportPackets();
+    return progress;
+  }
+
+  bool handshake_complete() const { return handshake_complete_; }
+
+  bool request_headers_received() const { return request_headers_received_; }
+
+  std::size_t executed_action_count() const { return next_action_; }
+
+  std::uint16_t server_port() const { return server_port_; }
+
+ private:
+  // ngtcp2 acknowledges QUIC writes by stream offset, while nghttp3 accepts
+  // acknowledgement only for its own serialized bytes. Track those regions
+  // separately from deliberately raw script writes.
+  struct StreamState {
+    struct ManagedWriteRange {
+      std::uint64_t begin = 0;
+      std::uint64_t end = 0;
+    };
+
+    std::int64_t id = kNoStreamId;
+    std::uint64_t write_offset = 0;
+    std::vector<ManagedWriteRange> managed_write_ranges;
+    std::vector<std::uint64_t> managed_fin_offsets;
+    std::size_t next_managed_ack_range = 0;
+    std::size_t next_managed_fin_offset = 0;
+  };
+
+  // Queue at most one application write at a time. The byte string is kept in
+  // retained_writes_ because ngtcp2 may submit only a prefix on each turn.
+  struct PendingWrite {
+    std::int64_t stream_id = kNoStreamId;
+    const std::string* bytes = nullptr;
+    std::size_t offset = 0;
+    bool finish_stream = false;
+    bool nghttp3_managed = false;
+    bool completes_action = false;
+
+    bool active() const { return stream_id != kNoStreamId; }
+
+    void Clear() {
+      stream_id = kNoStreamId;
+      bytes = nullptr;
+      offset = 0;
+      finish_stream = false;
+      nghttp3_managed = false;
+      completes_action = false;
+    }
+  };
+
+  // nghttp3 pulls response bytes through a callback. This state lets that
+  // callback preserve the scenario's chunk boundaries and final-stream intent.
+  struct ResponseBodyState {
+    std::vector<std::string> chunks;
+    std::size_t next_chunk = 0;
+    bool finish_stream = false;
+    bool has_trailers = false;
+  };
+
+  enum class WriteResult {
+    kComplete,
+    kBlocked,
+    kFailed,
+  };
+
+  // Tear down in protocol-layer order: HTTP/3 retains references into QUIC,
+  // and OpenSSL's app data points back to this object until it is cleared.
+  void ResetPeer() {
+    OpenSslErrorQueueGuard error_guard;
+    pending_write_.Clear();
+    nghttp3_conn_del(http3_connection_);
+    http3_connection_ = nullptr;
+    ngtcp2_conn_del(quic_connection_);
+    quic_connection_ = nullptr;
+    if (tls_connection_ != nullptr) {
+      SSL_set_app_data(tls_connection_, nullptr);
+      SSL_free(tls_connection_);
+      tls_connection_ = nullptr;
+    }
+    ngtcp2_crypto_ossl_ctx_del(crypto_context_);
+    crypto_context_ = nullptr;
+    streams_.clear();
+    retained_writes_.clear();
+    if (server_fd_ >= 0) {
+      (void)::close(server_fd_);
+      server_fd_ = -1;
+    }
+
+    scenario_ = nullptr;
+    role_stream_ids_.fill(kNoStreamId);
+    std::memset(&local_address_, 0, sizeof(local_address_));
+    std::memset(&remote_address_, 0, sizeof(remote_address_));
+    ngtcp2_path_storage_zero(&path_storage_);
+    response_body_.chunks.clear();
+    response_body_.next_chunk = 0;
+    response_body_.finish_stream = false;
+    response_body_.has_trailers = false;
+    next_action_ = 0;
+    server_port_ = 0;
+    socket_opened_ = false;
+    handshake_complete_ = false;
+    request_headers_received_ = false;
+    server_streams_bound_ = false;
+    bootstrap_drained_ = false;
+    waiting_for_h3_drain_ = false;
+    waiting_drain_completes_action_ = false;
+    final_response_submitted_ = false;
+    default_response_started_ = false;
+    http3_failed_ = false;
+    transport_failed_ = false;
+    close_requested_ = false;
+    close_sent_ = false;
+    close_error_code_ = 0;
+    random_counter_ = 0;
+  }
+
+  // ngtcp2 calls into this group while it owns QUIC parsing and encryption.
+  // Each callback bridges a transport event into the separately-owned nghttp3
+  // connection or records enough state for a later application turn.
+  static ngtcp2_conn* GetQuicConnection(ngtcp2_crypto_conn_ref* connection_ref) {
+    auto* self = static_cast<Http3MockServerImpl*>(connection_ref->user_data);
+    return self == nullptr ? nullptr : self->quic_connection_;
+  }
+
+  static int HandshakeCompleted(ngtcp2_conn* /*connection*/, void* user_data) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr) {
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    self->handshake_complete_ = true;
+    return 0;
+  }
+
+  static int ReceiveTransmitKey(ngtcp2_conn* /*connection*/, ngtcp2_encryption_level level, void* user_data) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr) {
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    if (level != NGTCP2_ENCRYPTION_LEVEL_1RTT || self->server_streams_bound_) {
+      return 0;
+    }
+    // HTTP/3 application streams become valid only after 1-RTT keys exist.
+    // Bind its critical streams before allowing script output onto the peer.
+    if (!self->CreateHttp3Connection()) {
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    (void)self->CreateServerStreams();
+    return self->server_streams_bound_ ? 0 : NGTCP2_ERR_CALLBACK_FAILURE;
+  }
+
+  static void GenerateRandomBytes(std::uint8_t* destination, std::size_t length,
+                                  const ngtcp2_rand_ctx* random_context) {
+    if (random_context == nullptr) {
+      std::memset(destination, 0, length);
+      return;
+    }
+    auto* self = static_cast<Http3MockServerImpl*>(random_context->native_handle);
+    if (self == nullptr) {
+      std::memset(destination, 0, length);
+      return;
+    }
+    self->FillRandom(destination, length);
+  }
+
+  static int GetNewConnectionId(ngtcp2_conn* /*connection*/, ngtcp2_cid* connection_id,
+                                ngtcp2_stateless_reset_token* reset_token, std::size_t connection_id_length,
+                                void* user_data) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr || connection_id == nullptr || reset_token == nullptr ||
+        connection_id_length > sizeof(connection_id->data)) {
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    connection_id->datalen = connection_id_length;
+    self->FillRandom(connection_id->data, connection_id_length);
+    self->FillRandom(reset_token->data, sizeof(reset_token->data));
+    return 0;
+  }
+
+  static int OpenRemoteStream(ngtcp2_conn* /*connection*/, std::int64_t stream_id, void* user_data) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr || self->streams_.size() >= kMaxStreams) {
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    StreamState state;
+    state.id = stream_id;
+    self->streams_.push_back(state);
+    if (self->role_stream_ids_[kResponseStream] == kNoStreamId && ngtcp2_is_bidi_stream(stream_id)) {
+      self->role_stream_ids_[kResponseStream] = stream_id;
+    }
+    return 0;
+  }
+
+  // ngtcp2 presents decrypted stream bytes; nghttp3 parses the HTTP/3 layer.
+  // Extending QUIC's flow-control windows by the consumed amount keeps only
+  // parsed bytes eligible for further client transmission.
+  static int ReceiveQuicStreamData(ngtcp2_conn* connection, std::uint32_t flags, std::int64_t stream_id,
+                                   std::uint64_t /*offset*/, const std::uint8_t* data, std::size_t length,
+                                   void* user_data, void* /*stream_user_data*/) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr || self->http3_connection_ == nullptr || self->http3_failed_) {
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    const nghttp3_ssize consumed =
+        nghttp3_conn_read_stream2(self->http3_connection_, stream_id, data, length, flags & NGTCP2_STREAM_DATA_FLAG_FIN,
+                                  ngtcp2_conn_get_timestamp(connection));
+    if (consumed < 0) {
+      self->http3_failed_ = true;
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    ngtcp2_conn_extend_max_stream_offset(connection, stream_id, static_cast<std::uint64_t>(consumed));
+    ngtcp2_conn_extend_max_offset(connection, static_cast<std::uint64_t>(consumed));
+    return 0;
+  }
+
+  // A transport acknowledgement covers both raw fuzz bytes and nghttp3 output.
+  // Report only intersecting nghttp3-managed ranges back to nghttp3; otherwise
+  // its write offsets would advance for bytes it never generated.
+  static int AckedStreamDataOffset(ngtcp2_conn* /*connection*/, std::int64_t stream_id, std::uint64_t offset,
+                                   std::uint64_t length, void* user_data, void* /*stream_user_data*/) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr || self->http3_connection_ == nullptr || self->http3_failed_) {
+      return 0;
+    }
+
+    StreamState* stream = self->FindStream(stream_id);
+    if (stream == nullptr || offset > UINT64_MAX - length) {
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+
+    if (length == 0) {
+      if (stream->next_managed_fin_offset < stream->managed_fin_offsets.size() &&
+          stream->managed_fin_offsets[stream->next_managed_fin_offset] == offset) {
+        ++stream->next_managed_fin_offset;
+        if (nghttp3_conn_add_ack_offset(self->http3_connection_, stream_id, 0) != 0) {
+          self->http3_failed_ = true;
+          return NGTCP2_ERR_CALLBACK_FAILURE;
+        }
+      }
+      return 0;
+    }
+
+    const std::uint64_t end = offset + length;
+    std::uint64_t managed_length = 0;
+    for (std::size_t index = stream->next_managed_ack_range; index < stream->managed_write_ranges.size(); ++index) {
+      const StreamState::ManagedWriteRange& range = stream->managed_write_ranges[index];
+      if (range.end <= offset) {
+        stream->next_managed_ack_range = index + 1;
+        continue;
+      }
+      if (range.begin >= end) {
+        break;
+      }
+      managed_length += std::min(range.end, end) - std::max(range.begin, offset);
+      if (range.end <= end) {
+        stream->next_managed_ack_range = index + 1;
+      }
+    }
+
+    if (managed_length != 0 && nghttp3_conn_add_ack_offset(self->http3_connection_, stream_id, managed_length) != 0) {
+      self->http3_failed_ = true;
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    return 0;
+  }
+
+  // Keep nghttp3's stream lifecycle synchronized with QUIC resets, STOP_SENDING
+  // events, and close error-code flags.
+  static int CloseQuicStream(ngtcp2_conn* /*connection*/, std::uint32_t flags, std::int64_t stream_id,
+                             std::uint64_t receive_error_code, std::uint64_t transmit_error_code, void* user_data,
+                             void* /*stream_user_data*/) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr || self->http3_connection_ == nullptr || self->http3_failed_) {
+      return 0;
+    }
+    std::uint32_t http3_flags = NGHTTP3_STREAM_CLOSE_FLAG_NONE;
+    if ((flags & NGTCP2_STREAM_CLOSE2_FLAG_RX_APP_ERROR_CODE_SET) != 0) {
+      http3_flags |= NGHTTP3_STREAM_CLOSE_FLAG_RX_APP_ERROR_CODE_SET;
+    }
+    if ((flags & NGTCP2_STREAM_CLOSE2_FLAG_TX_APP_ERROR_CODE_SET) != 0) {
+      http3_flags |= NGHTTP3_STREAM_CLOSE_FLAG_TX_APP_ERROR_CODE_SET;
+    }
+    const int result = nghttp3_conn_close_stream2(self->http3_connection_, http3_flags, stream_id, receive_error_code,
+                                                  transmit_error_code);
+    if (result != 0 && result != NGHTTP3_ERR_STREAM_NOT_FOUND) {
+      self->http3_failed_ = true;
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    return 0;
+  }
+
+  static int ResetQuicStream(ngtcp2_conn* /*connection*/, std::int64_t stream_id, std::uint64_t /*final_size*/,
+                             std::uint64_t /*application_error_code*/, void* user_data, void* /*stream_user_data*/) {
+    return ShutdownHttp3StreamRead(stream_id, user_data);
+  }
+
+  static int StopSendingQuicStream(ngtcp2_conn* /*connection*/, std::int64_t stream_id,
+                                   std::uint64_t /*application_error_code*/, void* user_data,
+                                   void* /*stream_user_data*/) {
+    return ShutdownHttp3StreamRead(stream_id, user_data);
+  }
+
+  static int ShutdownHttp3StreamRead(std::int64_t stream_id, void* user_data) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr || self->http3_connection_ == nullptr || self->http3_failed_) {
+      return 0;
+    }
+    const int result = nghttp3_conn_shutdown_stream_read(self->http3_connection_, stream_id);
+    if (result != 0 && result != NGHTTP3_ERR_STREAM_NOT_FOUND) {
+      self->http3_failed_ = true;
+      return NGTCP2_ERR_CALLBACK_FAILURE;
+    }
+    return 0;
+  }
+
+  // Create HTTP/3 once the QUIC handshake can carry application traffic.
+  // Dynamic QPACK is intentionally disabled so scenarios cannot retain table
+  // state beyond the bounded peer lifetime.
+  bool CreateHttp3Connection() {
+    if (http3_connection_ != nullptr) {
+      return true;
+    }
+    nghttp3_callbacks callbacks = {};
+    callbacks.recv_data = &ReceiveRequestData;
+    callbacks.deferred_consume = &DeferredConsumeRequestData;
+    callbacks.end_headers = &EndRequestHeaders;
+    callbacks.end_stream = &EndRequestStream;
+    nghttp3_settings settings;
+    nghttp3_settings_default(&settings);
+    settings.qpack_max_dtable_capacity = 0;
+    settings.qpack_encoder_max_dtable_capacity = 0;
+    settings.qpack_blocked_streams = 0;
+    if (nghttp3_conn_server_new(&http3_connection_, &callbacks, &settings, nullptr, this) != 0) {
+      http3_failed_ = true;
+      return false;
+    }
+    nghttp3_conn_set_max_concurrent_streams(http3_connection_, kMaxStreams);
+    return true;
+  }
+
+  // QUIC needs unpredictable-looking connection IDs and reset tokens, but
+  // fuzzing needs deterministic reruns. This local generator is not used for
+  // cryptographic secrecy.
+  void FillRandom(std::uint8_t* destination, std::size_t length) {
+    std::uint64_t state = ++random_counter_ * UINT64_C(0x9e3779b97f4a7c15);
+    for (std::size_t index = 0; index < length; ++index) {
+      state ^= state >> 12U;
+      state ^= state << 25U;
+      state ^= state >> 27U;
+      destination[index] = static_cast<std::uint8_t>((state * UINT64_C(0x2545f4914f6cdd1d)) >> 56U);
+    }
+  }
+
+  // The first valid Initial establishes the sole remote endpoint. Construct
+  // all three protocol layers here because ngtcp2's crypto callbacks need a
+  // live server-side SSL object while processing this packet.
+  bool InitializeConnection(const ngtcp2_pkt_hd& header, const struct sockaddr_in& remote_address) {
+    if (quic_connection_ != nullptr || header.type != NGTCP2_PKT_INITIAL) {
+      return false;
+    }
+
+    remote_address_ = remote_address;
+    ngtcp2_path_storage_init(&path_storage_, reinterpret_cast<const ngtcp2_sockaddr*>(&local_address_),
+                             sizeof(local_address_), reinterpret_cast<const ngtcp2_sockaddr*>(&remote_address_),
+                             sizeof(remote_address_), nullptr);
+
+    ngtcp2_callbacks callbacks = {};
+    callbacks.recv_client_initial = ngtcp2_crypto_recv_client_initial_cb;
+    callbacks.recv_crypto_data = ngtcp2_crypto_recv_crypto_data_cb;
+    callbacks.handshake_completed = &HandshakeCompleted;
+    callbacks.encrypt = ngtcp2_crypto_encrypt_cb;
+    callbacks.decrypt = ngtcp2_crypto_decrypt_cb;
+    callbacks.hp_mask = ngtcp2_crypto_hp_mask_cb;
+    callbacks.recv_stream_data = &ReceiveQuicStreamData;
+    callbacks.acked_stream_data_offset = &AckedStreamDataOffset;
+    callbacks.stream_open = &OpenRemoteStream;
+    callbacks.stream_reset = &ResetQuicStream;
+    callbacks.rand = &GenerateRandomBytes;
+    callbacks.update_key = ngtcp2_crypto_update_key_cb;
+    callbacks.delete_crypto_aead_ctx = ngtcp2_crypto_delete_crypto_aead_ctx_cb;
+    callbacks.delete_crypto_cipher_ctx = ngtcp2_crypto_delete_crypto_cipher_ctx_cb;
+    callbacks.stream_stop_sending = &StopSendingQuicStream;
+    callbacks.version_negotiation = ngtcp2_crypto_version_negotiation_cb;
+    callbacks.recv_tx_key = &ReceiveTransmitKey;
+    callbacks.get_new_connection_id2 = &GetNewConnectionId;
+    callbacks.get_path_challenge_data2 = ngtcp2_crypto_get_path_challenge_data2_cb;
+    callbacks.stream_close2 = &CloseQuicStream;
+
+    ngtcp2_settings settings;
+    ngtcp2_settings_default(&settings);
+    settings.initial_ts = QuicNow();
+    settings.rand_ctx.native_handle = this;
+    settings.no_pmtud = 1;
+    settings.max_tx_udp_payload_size = packet_buffer_.size();
+
+    ngtcp2_transport_params parameters;
+    ngtcp2_transport_params_default(&parameters);
+    parameters.initial_max_stream_data_bidi_local = kMaxPendingPlaintextBytes;
+    parameters.initial_max_stream_data_bidi_remote = kMaxPendingPlaintextBytes;
+    parameters.initial_max_stream_data_uni = kMaxPendingPlaintextBytes;
+    parameters.initial_max_data = kMaxPendingPlaintextBytes * 4U;
+    parameters.initial_max_streams_bidi = kMaxStreams;
+    parameters.initial_max_streams_uni = kMaxStreams;
+    parameters.max_idle_timeout = 5U * NGTCP2_SECONDS;
+    parameters.active_connection_id_limit = 2;
+    parameters.original_dcid = header.dcid;
+    parameters.original_dcid_present = 1;
+
+    ngtcp2_cid server_cid = {};
+    server_cid.datalen = kServerConnectionIdBytes;
+    FillRandom(server_cid.data, server_cid.datalen);
+    if (ngtcp2_conn_server_new(&quic_connection_, &header.scid, &server_cid, &path_storage_.path, header.version,
+                               &callbacks, &settings, &parameters, nullptr, this) != 0) {
+      return false;
+    }
+
+    if (ngtcp2_crypto_ossl_ctx_new(&crypto_context_, nullptr) != 0) {
+      return false;
+    }
+    tls_connection_ = SSL_new(context_);
+    if (tls_connection_ == nullptr) {
+      return false;
+    }
+    ngtcp2_crypto_ossl_ctx_set_ssl(crypto_context_, tls_connection_);
+    if (ngtcp2_crypto_ossl_configure_server_session(tls_connection_) != 0) {
+      return false;
+    }
+    SSL_set_app_data(tls_connection_, &crypto_connection_ref_);
+    SSL_set_accept_state(tls_connection_);
+    ngtcp2_conn_set_tls_native_handle(quic_connection_, crypto_context_);
+    return true;
+  }
+
+  // Drain a bounded datagram batch. Before connection setup, accept only a
+  // valid QUIC Initial; afterwards, ignore packets from other UDP endpoints.
+  std::size_t ReadDatagrams() {
+    std::size_t progress = 0;
+    for (std::size_t packet = 0; packet < kMaxDatagramsPerTurn; ++packet) {
+      struct sockaddr_in remote_address = {};
+      socklen_t remote_length = sizeof(remote_address);
+      const ssize_t received = ::recvfrom(server_fd_, receive_buffer_.data(), receive_buffer_.size(), 0,
+                                          reinterpret_cast<struct sockaddr*>(&remote_address), &remote_length);
+      if (received < 0) {
+        if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+          transport_failed_ = true;
+        }
+        break;
+      }
+      if (received == 0 || remote_length != sizeof(remote_address) || remote_address.sin_family != AF_INET) {
+        continue;
+      }
+      ++progress;
+
+      if (quic_connection_ == nullptr) {
+        ngtcp2_pkt_hd header = {};
+        if (ngtcp2_accept(&header, receive_buffer_.data(), static_cast<std::size_t>(received)) != 0) {
+          continue;
+        }
+        if (!InitializeConnection(header, remote_address)) {
+          transport_failed_ = true;
+          return progress;
+        }
+      } else if (remote_address.sin_port != remote_address_.sin_port ||
+                 remote_address.sin_addr.s_addr != remote_address_.sin_addr.s_addr) {
+        continue;
+      }
+
+      ngtcp2_pkt_info packet_info = {};
+      const int result = ngtcp2_conn_read_pkt(quic_connection_, &path_storage_.path, &packet_info,
+                                              receive_buffer_.data(), static_cast<std::size_t>(received), QuicNow());
+      if (result != 0) {
+        transport_failed_ = true;
+        return progress;
+      }
+    }
+    return progress;
+  }
+
+  // ngtcp2 timers can make handshake, loss-recovery, or close packets ready
+  // even when curl has not sent a new UDP datagram this turn.
+  std::size_t HandleExpiry() {
+    if (quic_connection_ == nullptr) {
+      return 0;
+    }
+    const ngtcp2_tstamp now = QuicNow();
+    if (ngtcp2_conn_get_expiry2(quic_connection_) > now) {
+      return 0;
+    }
+    const int result = ngtcp2_conn_handle_expiry(quic_connection_, now);
+    if (result != 0) {
+      transport_failed_ = true;
+    }
+    return 1;
+  }
+
+  // A nonblocking socket can defer a packet without making the peer invalid.
+  // Hard send errors are terminal because no later turn can repair the path.
+  bool SendPacket(const ngtcp2_path& path, const std::uint8_t* data, std::size_t length) {
+    const ngtcp2_addr* destination = &path.remote;
+    if (destination->addr == nullptr || destination->addrlen == 0) {
+      destination = &path_storage_.path.remote;
+    }
+    const ssize_t sent = ::sendto(server_fd_, data, length, 0,
+                                  reinterpret_cast<const struct sockaddr*>(destination->addr), destination->addrlen);
+    if (sent == static_cast<ssize_t>(length)) {
+      return true;
+    }
+    if (sent < 0 && (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)) {
+      return false;
+    }
+    transport_failed_ = true;
+    return false;
+  }
+
+  // Serialize all QUIC control traffic after application writes. A requested
+  // CONNECTION_CLOSE takes priority and is emitted at most once.
+  std::size_t FlushTransportPackets() {
+    if (quic_connection_ == nullptr || transport_failed_ || close_sent_) {
+      return 0;
+    }
+
+    if (close_requested_) {
+      ngtcp2_ccerr error;
+      ngtcp2_ccerr_default(&error);
+      ngtcp2_ccerr_set_application_error(&error, close_error_code_, nullptr, 0);
+      ngtcp2_path_storage output_path;
+      ngtcp2_path_storage_zero(&output_path);
+      ngtcp2_pkt_info packet_info = {};
+      const ngtcp2_tstamp now = QuicNow();
+      const ngtcp2_ssize written = ngtcp2_conn_write_connection_close(
+          quic_connection_, &output_path.path, &packet_info, packet_buffer_.data(), packet_buffer_.size(), &error, now);
+      if (written < 0) {
+        transport_failed_ = true;
+        return 0;
+      }
+      close_sent_ = true;
+      if (written == 0) {
+        return 1;
+      }
+      ngtcp2_conn_update_pkt_tx_time(quic_connection_, now);
+      (void)SendPacket(output_path.path, packet_buffer_.data(), static_cast<std::size_t>(written));
+      return 1;
+    }
+
+    std::size_t progress = 0;
+    for (std::size_t packet = 0; packet < kMaxWritesPerTurn; ++packet) {
+      ngtcp2_path_storage output_path;
+      ngtcp2_path_storage_zero(&output_path);
+      ngtcp2_pkt_info packet_info = {};
+      const ngtcp2_tstamp now = QuicNow();
+      const ngtcp2_ssize written = ngtcp2_conn_write_pkt(quic_connection_, &output_path.path, &packet_info,
+                                                         packet_buffer_.data(), packet_buffer_.size(), now);
+      if (written < 0) {
+        transport_failed_ = true;
+        break;
+      }
+      if (written == 0) {
+        break;
+      }
+      ngtcp2_conn_update_pkt_tx_time(quic_connection_, now);
+      if (!SendPacket(output_path.path, packet_buffer_.data(), static_cast<std::size_t>(written))) {
+        break;
+      }
+      ++progress;
+    }
+    return progress;
+  }
+
+  // HTTP/3 requires one control stream and two QPACK streams before it can
+  // send response metadata. Their stream IDs are retained by role so script
+  // actions can target them without exposing transport-chosen IDs.
+  std::size_t CreateServerStreams() {
+    if (server_streams_bound_ || quic_connection_ == nullptr || http3_connection_ == nullptr || http3_failed_) {
+      return 0;
+    }
+
+    std::size_t progress = 0;
+    const std::array<StreamRoleIndex, 3> roles = {kControlStream, kQpackEncoderStream, kQpackDecoderStream};
+    for (const StreamRoleIndex role : roles) {
+      if (role_stream_ids_[role] != kNoStreamId) {
+        continue;
+      }
+      const std::int64_t stream_id = OpenUnidirectionalStream();
+      if (stream_id == kNoStreamId) {
+        return progress;
+      }
+      role_stream_ids_[role] = stream_id;
+      ++progress;
+    }
+
+    if (role_stream_ids_[kControlStream] == kNoStreamId || role_stream_ids_[kQpackEncoderStream] == kNoStreamId ||
+        role_stream_ids_[kQpackDecoderStream] == kNoStreamId) {
+      return progress;
+    }
+    if (nghttp3_conn_bind_qpack_streams(http3_connection_, role_stream_ids_[kQpackEncoderStream],
+                                        role_stream_ids_[kQpackDecoderStream]) != 0 ||
+        nghttp3_conn_bind_control_stream(http3_connection_, role_stream_ids_[kControlStream]) != 0) {
+      http3_failed_ = true;
+      return progress;
+    }
+    server_streams_bound_ = true;
+    return progress + 1;
+  }
+
+  std::int64_t OpenUnidirectionalStream() {
+    if (quic_connection_ == nullptr || streams_.size() >= kMaxStreams) {
+      return kNoStreamId;
+    }
+    std::int64_t stream_id = kNoStreamId;
+    if (ngtcp2_conn_open_uni_stream(quic_connection_, &stream_id, nullptr) != 0) {
+      return kNoStreamId;
+    }
+
+    StreamState state;
+    state.id = stream_id;
+    streams_.push_back(state);
+    return stream_id;
+  }
+
+  // Advance protocol-generated output before one scenario action. This keeps
+  // QPACK/control bytes causally ahead of raw writes and makes each turn's
+  // work bounded even when the client is blocked.
+  std::size_t DriveApplicationOutput() {
+    std::size_t progress = 0;
+
+    if (pending_write_.active()) {
+      const bool completes_action = pending_write_.completes_action;
+      const WriteResult result = FlushPendingWrite(&progress);
+      if (result == WriteResult::kBlocked) {
+        return progress;
+      }
+      if (result == WriteResult::kFailed && transport_failed_) {
+        return progress;
+      }
+      if (completes_action) {
+        ++next_action_;
+        return progress + 1;
+      }
+      if (result == WriteResult::kFailed && waiting_for_h3_drain_) {
+        waiting_for_h3_drain_ = false;
+        if (waiting_drain_completes_action_) {
+          ++next_action_;
+        }
+        return progress + 1;
+      }
+    }
+
+    if (!server_streams_bound_) {
+      return progress;
+    }
+    if (!bootstrap_drained_) {
+      if (http3_failed_ || PumpNghttp3(&progress)) {
+        bootstrap_drained_ = true;
+        ++progress;
+      }
+      return progress;
+    }
+    if (waiting_for_h3_drain_) {
+      if (http3_failed_ || PumpNghttp3(&progress)) {
+        waiting_for_h3_drain_ = false;
+        if (waiting_drain_completes_action_) {
+          ++next_action_;
+        }
+        waiting_drain_completes_action_ = false;
+        ++progress;
+      }
+      return progress;
+    }
+
+    // Reading a request can produce QPACK decoder instructions independently
+    // of a response action. Keep those ahead of script-controlled raw writes.
+    if (!http3_failed_ && !PumpNghttp3(&progress)) {
+      return progress;
+    }
+    if (transport_failed_) {
+      return progress;
+    }
+
+    const std::size_t action_count =
+        scenario_ == nullptr
+            ? 0
+            : std::min<std::size_t>(scenario_limits::kMaxHttp3Actions, scenario_->http3_plan().actions_size());
+    if (next_action_ >= action_count) {
+      // An empty H3 plan still needs one successful response after a request.
+      if (action_count == 0 && !default_response_started_ && request_headers_received_) {
+        default_response_started_ = true;
+        if (SubmitStructuredResponse(default_response_)) {
+          waiting_for_h3_drain_ = true;
+          waiting_drain_completes_action_ = false;
+          ++progress;
+        }
+      }
+      return progress;
+    }
+
+    const auto& action = scenario_->http3_plan().actions(static_cast<int>(next_action_));
+    if (action.has_structured_response()) {
+      if (!request_headers_received_) {
+        return progress;
+      }
+      if (SubmitStructuredResponse(action.structured_response())) {
+        waiting_for_h3_drain_ = true;
+        waiting_drain_completes_action_ = true;
+      } else {
+        ++next_action_;
+      }
+      return progress + 1;
+    }
+
+    if (action.has_stream_write()) {
+      const auto& write = action.stream_write();
+      const std::int64_t stream_id = StreamForRole(write.role());
+      if (stream_id == kNoStreamId) {
+        return progress;
+      }
+      const std::size_t length = std::min<std::size_t>(scenario_limits::kMaxHttp3RawWriteBytes, write.data().size());
+      QueueWrite(stream_id, write.data().substr(0, length), write.finish_stream(), false, true);
+      return progress + 1;
+    }
+
+    if (action.has_open_unidirectional_stream()) {
+      const auto& open = action.open_unidirectional_stream();
+      const std::int64_t stream_id = OpenUnidirectionalStream();
+      if (stream_id == kNoStreamId) {
+        ++next_action_;
+        return progress + 1;
+      }
+      const std::size_t length = std::min<std::size_t>(scenario_limits::kMaxHttp3RawWriteBytes, open.data().size());
+      QueueWrite(stream_id, open.data().substr(0, length), open.finish_stream(), false, true);
+      return progress + 1;
+    }
+
+    if (action.has_stream_reset()) {
+      const auto& reset = action.stream_reset();
+      const std::int64_t stream_id = StreamForRole(reset.role());
+      if (stream_id == kNoStreamId) {
+        return progress;
+      }
+      (void)ngtcp2_conn_shutdown_stream_write(quic_connection_, 0, stream_id,
+                                              reset.application_error_code() & scenario_limits::kMaxQuicVarint);
+      ++next_action_;
+      return progress + 1;
+    }
+
+    if (action.has_goaway()) {
+      const std::int64_t control_stream_id = StreamForRole(curl::fuzzer::proto::HTTP3_STREAM_CONTROL);
+      if (control_stream_id == kNoStreamId) {
+        return progress;
+      }
+      // HTTP/3 GOAWAY is a raw control-stream frame so its identifier remains
+      // directly mutation-controlled instead of being selected by nghttp3.
+      std::string payload;
+      AppendQuicVarint(&payload, action.goaway().id());
+      std::string frame;
+      AppendQuicVarint(&frame, 0x07U);
+      AppendQuicVarint(&frame, payload.size());
+      frame.append(payload);
+      QueueWrite(control_stream_id, std::move(frame), false, false, true);
+      return progress + 1;
+    }
+
+    if (action.has_connection_close()) {
+      close_error_code_ = action.connection_close().application_error_code() & scenario_limits::kMaxQuicVarint;
+      close_requested_ = true;
+      ++next_action_;
+      return progress + 1;
+    }
+
+    ++next_action_;
+    return progress + 1;
+  }
+
+  // Retain script and nghttp3 bytes until ngtcp2 accepts their full prefix.
+  // Only one pending write exists, preserving ordering between action types.
+  void QueueWrite(std::int64_t stream_id, std::string bytes, bool finish_stream, bool nghttp3_managed,
+                  bool completes_action) {
+    retained_writes_.push_back(std::make_unique<std::string>(std::move(bytes)));
+    pending_write_.stream_id = stream_id;
+    pending_write_.bytes = retained_writes_.back().get();
+    pending_write_.offset = 0;
+    pending_write_.finish_stream = finish_stream;
+    pending_write_.nghttp3_managed = nghttp3_managed;
+    pending_write_.completes_action = completes_action;
+  }
+
+  // Packetize one prefix through ngtcp2. For nghttp3-managed output, record
+  // the exact submitted offsets so its acknowledgement accounting can exclude
+  // interleaved raw writes on the same QUIC stream.
+  WriteResult FlushPendingWrite(std::size_t* progress) {
+    if (!pending_write_.active()) {
+      return WriteResult::kComplete;
+    }
+
+    if (pending_write_.bytes == nullptr || pending_write_.offset > pending_write_.bytes->size()) {
+      pending_write_.Clear();
+      return WriteResult::kFailed;
+    }
+
+    const std::size_t remaining = pending_write_.bytes->size() - pending_write_.offset;
+    if (remaining == 0 && !pending_write_.finish_stream) {
+      pending_write_.Clear();
+      ++*progress;
+      return WriteResult::kComplete;
+    }
+
+    ngtcp2_vec vector = {};
+    vector.base =
+        reinterpret_cast<std::uint8_t*>(const_cast<char*>(pending_write_.bytes->data() + pending_write_.offset));
+    vector.len = remaining;
+    const std::size_t vector_count = remaining == 0 ? 0 : 1;
+    const std::uint32_t flags =
+        pending_write_.finish_stream ? NGTCP2_WRITE_STREAM_FLAG_FIN : NGTCP2_WRITE_STREAM_FLAG_NONE;
+    ngtcp2_path_storage output_path;
+    ngtcp2_path_storage_zero(&output_path);
+    ngtcp2_pkt_info packet_info = {};
+    ngtcp2_ssize submitted = -1;
+    const ngtcp2_tstamp now = QuicNow();
+    const ngtcp2_ssize packet_length = ngtcp2_conn_writev_stream(
+        quic_connection_, &output_path.path, &packet_info, packet_buffer_.data(), packet_buffer_.size(), &submitted,
+        flags, pending_write_.stream_id, vector_count == 0 ? nullptr : &vector, vector_count, now);
+    if (packet_length == NGTCP2_ERR_STREAM_DATA_BLOCKED) {
+      return WriteResult::kBlocked;
+    }
+    if (packet_length == NGTCP2_ERR_STREAM_SHUT_WR || packet_length == NGTCP2_ERR_STREAM_NOT_FOUND) {
+      pending_write_.Clear();
+      return WriteResult::kFailed;
+    }
+    if (packet_length < 0) {
+      transport_failed_ = true;
+      pending_write_.Clear();
+      return WriteResult::kFailed;
+    }
+    if (packet_length == 0) {
+      return WriteResult::kBlocked;
+    }
+    ngtcp2_conn_update_pkt_tx_time(quic_connection_, now);
+    (void)SendPacket(output_path.path, packet_buffer_.data(), static_cast<std::size_t>(packet_length));
+    ++*progress;
+    if (transport_failed_) {
+      pending_write_.Clear();
+      return WriteResult::kFailed;
+    }
+
+    if (submitted >= 0) {
+      StreamState* stream = FindStream(pending_write_.stream_id);
+      if (stream == nullptr || static_cast<std::uint64_t>(submitted) > UINT64_MAX - stream->write_offset) {
+        transport_failed_ = true;
+        pending_write_.Clear();
+        return WriteResult::kFailed;
+      }
+      const std::uint64_t write_begin = stream->write_offset;
+      stream->write_offset += static_cast<std::uint64_t>(submitted);
+      if (pending_write_.nghttp3_managed) {
+        if (nghttp3_conn_add_write_offset(http3_connection_, pending_write_.stream_id,
+                                          static_cast<std::uint64_t>(submitted)) != 0) {
+          http3_failed_ = true;
+          pending_write_.Clear();
+          return WriteResult::kFailed;
+        }
+        if (submitted != 0) {
+          stream->managed_write_ranges.push_back({write_begin, stream->write_offset});
+        } else if (pending_write_.finish_stream && pending_write_.offset == pending_write_.bytes->size()) {
+          stream->managed_fin_offsets.push_back(write_begin);
+        }
+      }
+      pending_write_.offset += static_cast<std::size_t>(submitted);
+    }
+    if (submitted < 0 || pending_write_.offset != pending_write_.bytes->size()) {
+      return WriteResult::kBlocked;
+    }
+    pending_write_.Clear();
+    return WriteResult::kComplete;
+  }
+
+  // Let nghttp3 serialize response/control bytes, then feed each generated
+  // vector through the same QUIC write path as raw scenario data. Stop when a
+  // raw action is pending so it cannot be reordered behind generated output.
+  bool PumpNghttp3(std::size_t* progress) {
+    if (http3_connection_ == nullptr || http3_failed_) {
+      return true;
+    }
+
+    for (std::size_t operation = 0; operation < kMaxWritesPerTurn; ++operation) {
+      if (pending_write_.active()) {
+        if (!pending_write_.nghttp3_managed) {
+          return false;
+        }
+        const WriteResult result = FlushPendingWrite(progress);
+        if (result == WriteResult::kBlocked) {
+          return false;
+        }
+        if (result == WriteResult::kFailed) {
+          http3_failed_ = true;
+          return true;
+        }
+      }
+
+      std::array<nghttp3_vec, 16> vectors;
+      std::int64_t stream_id = -1;
+      int finish_stream = 0;
+      const nghttp3_ssize vector_count =
+          nghttp3_conn_writev_stream(http3_connection_, &stream_id, &finish_stream, vectors.data(), vectors.size());
+      if (vector_count < 0) {
+        http3_failed_ = true;
+        return true;
+      }
+      if (vector_count == 0 && stream_id == -1) {
+        return true;
+      }
+
+      StreamState* stream = FindStream(stream_id);
+      if (stream == nullptr) {
+        http3_failed_ = true;
+        return true;
+      }
+
+      std::string bytes;
+      if (vector_count > 0) {
+        std::size_t total = 0;
+        for (nghttp3_ssize index = 0; index < vector_count; ++index) {
+          if (vectors[static_cast<std::size_t>(index)].len > kMaxPendingPlaintextBytes - total) {
+            http3_failed_ = true;
+            return true;
+          }
+          total += vectors[static_cast<std::size_t>(index)].len;
+        }
+        bytes.reserve(total);
+        for (nghttp3_ssize index = 0; index < vector_count; ++index) {
+          const nghttp3_vec& vector = vectors[static_cast<std::size_t>(index)];
+          bytes.append(reinterpret_cast<const char*>(vector.base), vector.len);
+        }
+      }
+
+      QueueWrite(stream->id, std::move(bytes), finish_stream != 0, true, false);
+    }
+    return false;
+  }
+
+  // Convert a bounded schema response into nghttp3-owned fields and pull-based
+  // body state. Interim responses do not consume the single final response.
+  bool SubmitStructuredResponse(const curl::fuzzer::proto::Http3Response& response) {
+    if (http3_connection_ == nullptr || http3_failed_ || role_stream_ids_[kResponseStream] == kNoStreamId) {
+      return false;
+    }
+
+    std::uint32_t status_code = response.status_code();
+    if (status_code < 100U || status_code > 599U) {
+      status_code = 100U + status_code % 500U;
+    }
+    std::vector<std::pair<std::string, std::string>> fields;
+    fields.reserve(1 + std::min<std::size_t>(scenario_limits::kMaxHttp3Headers, response.response_headers_size()));
+    fields.emplace_back(":status", std::to_string(status_code));
+    AppendHeaders(&fields, response.response_headers(), scenario_limits::kMaxHttp3Headers);
+    const std::vector<nghttp3_nv> name_values = MakeNameValues(fields);
+    const std::int64_t response_stream_id = static_cast<std::int64_t>(role_stream_ids_[kResponseStream]);
+
+    if (status_code < 200U) {
+      return nghttp3_conn_submit_info(http3_connection_, response_stream_id, name_values.data(), name_values.size()) ==
+             0;
+    }
+    if (final_response_submitted_) {
+      return false;
+    }
+
+    response_body_.chunks.clear();
+    response_body_.next_chunk = 0;
+    response_body_.finish_stream = response.finish_stream();
+    response_body_.has_trailers = response.response_trailers_size() != 0;
+    std::size_t body_bytes = 0;
+    const std::size_t body_chunks =
+        std::min<std::size_t>(scenario_limits::kMaxHttp3BodyChunks, response.body_chunks_size());
+    response_body_.chunks.reserve(body_chunks);
+    for (std::size_t index = 0; index < body_chunks && body_bytes < scenario_limits::kMaxHttp3BodyBytes; ++index) {
+      const std::string& source = response.body_chunks(static_cast<int>(index));
+      const std::size_t length = std::min(source.size(), scenario_limits::kMaxHttp3BodyBytes - body_bytes);
+      response_body_.chunks.emplace_back(source.data(), length);
+      body_bytes += length;
+    }
+
+    nghttp3_data_reader reader = {};
+    reader.read_data = &ReadResponseBody;
+    if (nghttp3_conn_submit_response(http3_connection_, response_stream_id, name_values.data(), name_values.size(),
+                                     &reader) != 0) {
+      return false;
+    }
+    final_response_submitted_ = true;
+
+    if (response_body_.has_trailers) {
+      std::vector<std::pair<std::string, std::string>> trailers;
+      trailers.reserve(std::min<std::size_t>(scenario_limits::kMaxHttp3Trailers, response.response_trailers_size()));
+      AppendHeaders(&trailers, response.response_trailers(), scenario_limits::kMaxHttp3Trailers);
+      const std::vector<nghttp3_nv> trailer_values = MakeNameValues(trailers);
+      if (nghttp3_conn_submit_trailers(http3_connection_, response_stream_id, trailer_values.data(),
+                                       trailer_values.size()) != 0) {
+        http3_failed_ = true;
+      }
+    }
+    return true;
+  }
+
+  template <typename RepeatedHeaders>
+  static void AppendHeaders(std::vector<std::pair<std::string, std::string>>* destination,
+                            const RepeatedHeaders& source, std::size_t count_limit) {
+    std::size_t remaining = scenario_limits::kMaxHttp3HeaderBytes;
+    const std::size_t count = std::min<std::size_t>(count_limit, source.size());
+    for (std::size_t index = 0; index < count && remaining != 0; ++index) {
+      std::string name = NormalizeHeaderName(source.Get(static_cast<int>(index)).name());
+      std::string value = NormalizeHeaderValue(source.Get(static_cast<int>(index)).value());
+      if (name.size() > remaining) {
+        name.resize(remaining);
+        value.clear();
+      } else if (value.size() > remaining - name.size()) {
+        value.resize(remaining - name.size());
+      }
+      remaining -= name.size() + value.size();
+      destination->emplace_back(std::move(name), std::move(value));
+    }
+  }
+
+  static std::vector<nghttp3_nv> MakeNameValues(const std::vector<std::pair<std::string, std::string>>& fields) {
+    std::vector<nghttp3_nv> name_values;
+    name_values.reserve(fields.size());
+    for (const auto& field : fields) {
+      nghttp3_nv name_value = {};
+      name_value.name = reinterpret_cast<std::uint8_t*>(const_cast<char*>(field.first.data()));
+      name_value.value = reinterpret_cast<std::uint8_t*>(const_cast<char*>(field.second.data()));
+      name_value.namelen = field.first.size();
+      name_value.valuelen = field.second.size();
+      name_value.flags = NGHTTP3_NV_FLAG_NONE;
+      name_values.push_back(name_value);
+    }
+    return name_values;
+  }
+
+  StreamState* FindStream(std::int64_t stream_id) {
+    for (StreamState& stream : streams_) {
+      if (stream.id == stream_id) {
+        return &stream;
+      }
+    }
+    return nullptr;
+  }
+
+  std::int64_t StreamForRole(curl::fuzzer::proto::Http3StreamRole role) {
+    const int role_value = static_cast<int>(role);
+    if (role_value < 0 || role_value >= static_cast<int>(kStreamRoleCount)) {
+      return kNoStreamId;
+    }
+    return role_stream_ids_[static_cast<std::size_t>(role_value)];
+  }
+
+  // nghttp3 callbacks replenish QUIC flow-control credit only as application
+  // bytes are consumed, then discover the first request stream for responses.
+  static int ReceiveRequestData(nghttp3_conn* /*connection*/, std::int64_t stream_id, const std::uint8_t* /*data*/,
+                                std::size_t data_length, void* user_data, void* /*stream_user_data*/) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self != nullptr && self->quic_connection_ != nullptr) {
+      ngtcp2_conn_extend_max_stream_offset(self->quic_connection_, stream_id, data_length);
+      ngtcp2_conn_extend_max_offset(self->quic_connection_, data_length);
+    }
+    return 0;
+  }
+
+  static int DeferredConsumeRequestData(nghttp3_conn* /*connection*/, std::int64_t stream_id, std::size_t consumed,
+                                        void* user_data, void* /*stream_user_data*/) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self != nullptr && self->quic_connection_ != nullptr) {
+      ngtcp2_conn_extend_max_stream_offset(self->quic_connection_, stream_id, consumed);
+      ngtcp2_conn_extend_max_offset(self->quic_connection_, consumed);
+    }
+    return 0;
+  }
+
+  static int EndRequestHeaders(nghttp3_conn* /*connection*/, std::int64_t stream_id, int /*finish_stream*/,
+                               void* user_data, void* /*stream_user_data*/) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self != nullptr) {
+      if (self->role_stream_ids_[kResponseStream] == kNoStreamId) {
+        self->role_stream_ids_[kResponseStream] = stream_id;
+        if (self->FindStream(stream_id) == nullptr && self->streams_.size() < kMaxStreams) {
+          StreamState state;
+          state.id = stream_id;
+          self->streams_.push_back(state);
+        }
+      }
+      if (self->role_stream_ids_[kResponseStream] == stream_id) {
+        self->request_headers_received_ = true;
+      }
+    }
+    return 0;
+  }
+
+  static int EndRequestStream(nghttp3_conn* /*connection*/, std::int64_t /*stream_id*/, void* /*user_data*/,
+                              void* /*stream_user_data*/) {
+    return 0;
+  }
+
+  // nghttp3 pulls one schema body chunk per call. EOF may keep the stream open
+  // for trailers or a deliberate no-FIN response.
+  static nghttp3_ssize ReadResponseBody(nghttp3_conn* /*connection*/, std::int64_t /*stream_id*/, nghttp3_vec* vectors,
+                                        std::size_t vector_count, std::uint32_t* flags, void* user_data,
+                                        void* /*stream_user_data*/) {
+    auto* self = static_cast<Http3MockServerImpl*>(user_data);
+    if (self == nullptr || vectors == nullptr || vector_count == 0 || flags == nullptr) {
+      return NGHTTP3_ERR_CALLBACK_FAILURE;
+    }
+
+    while (self->response_body_.next_chunk < self->response_body_.chunks.size() &&
+           self->response_body_.chunks[self->response_body_.next_chunk].empty()) {
+      ++self->response_body_.next_chunk;
+    }
+    if (self->response_body_.next_chunk == self->response_body_.chunks.size()) {
+      *flags = NGHTTP3_DATA_FLAG_EOF;
+      if (!self->response_body_.finish_stream && !self->response_body_.has_trailers) {
+        *flags |= NGHTTP3_DATA_FLAG_NO_END_STREAM;
+      }
+      return 0;
+    }
+
+    const std::string& chunk = self->response_body_.chunks[self->response_body_.next_chunk++];
+    vectors[0].base = reinterpret_cast<std::uint8_t*>(const_cast<char*>(chunk.data()));
+    vectors[0].len = chunk.size();
+    *flags = NGHTTP3_DATA_FLAG_NONE;
+    if (self->response_body_.next_chunk == self->response_body_.chunks.size()) {
+      *flags |= NGHTTP3_DATA_FLAG_EOF;
+      if (!self->response_body_.finish_stream && !self->response_body_.has_trailers) {
+        *flags |= NGHTTP3_DATA_FLAG_NO_END_STREAM;
+      }
+    }
+    return 1;
+  }
+
+  // Layer-owned transport state. The destruction order in ResetPeer mirrors
+  // these dependencies: HTTP/3, QUIC, TLS adapter, then TLS context/socket.
+  SSL_CTX* context_ = nullptr;
+  ngtcp2_conn* quic_connection_ = nullptr;
+  SSL* tls_connection_ = nullptr;
+  ngtcp2_crypto_ossl_ctx* crypto_context_ = nullptr;
+  ngtcp2_crypto_conn_ref crypto_connection_ref_;
+  nghttp3_conn* http3_connection_ = nullptr;
+  const curl::fuzzer::proto::Scenario* scenario_ = nullptr;
+  std::vector<StreamState> streams_;
+  std::vector<std::unique_ptr<std::string>> retained_writes_;
+  std::array<std::int64_t, kStreamRoleCount> role_stream_ids_;
+  PendingWrite pending_write_;
+  ResponseBodyState response_body_;
+  curl::fuzzer::proto::Http3Response default_response_;
+  ngtcp2_path_storage path_storage_ = {};
+  struct sockaddr_in local_address_ = {};
+  struct sockaddr_in remote_address_ = {};
+  std::array<std::uint8_t, kReceiveBufferBytes> receive_buffer_ = {};
+  std::array<std::uint8_t, NGTCP2_MAX_UDP_PAYLOAD_SIZE> packet_buffer_ = {};
+  std::uint64_t random_counter_ = 0;
+  std::uint64_t close_error_code_ = 0;
+  std::size_t next_action_ = 0;
+  int server_fd_ = -1;
+  std::uint16_t server_port_ = 0;
+  bool socket_opened_ = false;
+  bool handshake_complete_ = false;
+  bool request_headers_received_ = false;
+  bool server_streams_bound_ = false;
+  bool bootstrap_drained_ = false;
+  bool waiting_for_h3_drain_ = false;
+  bool waiting_drain_completes_action_ = false;
+  bool final_response_submitted_ = false;
+  bool default_response_started_ = false;
+  bool http3_failed_ = false;
+  bool transport_failed_ = false;
+  bool close_requested_ = false;
+  bool close_sent_ = false;
+};
+
+Http3MockServer::Http3MockServer() : Http3MockServer(curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC) {}
+
+Http3MockServer::Http3MockServer(curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain)
+    : impl_(new Http3MockServerImpl(certificate_chain)) {}
+
+Http3MockServer::~Http3MockServer() = default;
+
+void Http3MockServer::Install(CURL* easy) {
+  // Curl trusts the checked-in server certificate directly and must use HTTP/3
+  // rather than silently falling back to an HTTP/1 or HTTP/2 code path.
+  MockServerBase::Install(easy);
+  struct curl_blob trust_anchor = {const_cast<char*>(tls_test_credentials::kCertificatePem),
+                                   sizeof(tls_test_credentials::kCertificatePem) - 1, CURL_BLOB_NOCOPY};
+  (void)curl_easy_setopt(easy, CURLOPT_CAINFO_BLOB, &trust_anchor);
+  (void)curl_easy_setopt(easy, CURLOPT_SSL_VERIFYPEER, 1L);
+  (void)curl_easy_setopt(easy, CURLOPT_SSL_VERIFYHOST, 2L);
+  (void)curl_easy_setopt(easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3ONLY);
+}
+
+bool Http3MockServer::handshake_complete() const { return impl_ != nullptr && impl_->handshake_complete(); }
+
+bool Http3MockServer::request_headers_received() const { return impl_ != nullptr && impl_->request_headers_received(); }
+
+std::size_t Http3MockServer::executed_action_count() const {
+  return impl_ == nullptr ? 0 : impl_->executed_action_count();
+}
+
+std::uint16_t Http3MockServer::server_port() const { return impl_ == nullptr ? 0 : impl_->server_port(); }
+
+curl_socket_t Http3MockServer::HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) {
+  return impl_ == nullptr ? CURL_SOCKET_BAD : impl_->OpenSocket(purpose, address);
+}
+
+void Http3MockServer::RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) {
+  (void)easy;
+  if (impl_ == nullptr) {
+    return;
+  }
+  impl_->BeginScenario(scenario);
+
+  int still_running = 1;
+  int idle_iterations = 0;
+  if (MultiSocketDriver* driver = multi_socket_driver(); driver != nullptr) {
+    // Alternate curl readiness processing with one bounded peer turn. Neither
+    // side blocks, so an idle limit prevents a malformed case spinning forever.
+    CURLMcode result = driver->Start(&still_running);
+    for (int iteration = 0; result == CURLM_OK && iteration < kMaxDriveIterations && still_running != 0; ++iteration) {
+      std::size_t progress = impl_->DrivePeerTurn();
+      const MultiSocketDriver::DriveResult drive_result = driver->DriveReady(&still_running);
+      result = drive_result.code;
+      progress += drive_result.made_progress ? 1U : 0U;
+      if (progress != 0) {
+        idle_iterations = 0;
+      } else if (++idle_iterations >= kHttp3IdleIterations) {
+        break;
+      }
+    }
+    return;
+  }
+
+  // The fallback exercises curl's public multi-perform API while preserving
+  // the same peer-first/idle-limit behavior as the socket-action driver.
+  for (int iteration = 0; iteration < kMaxDriveIterations && still_running != 0; ++iteration) {
+    const int running_before = still_running;
+    const CURLMcode result = curl_multi_perform(multi, &still_running);
+    if (result != CURLM_OK) {
+      break;
+    }
+
+    std::size_t progress = still_running == running_before ? 0U : 1U;
+    progress += impl_->DrivePeerTurn();
+    if (progress != 0) {
+      idle_iterations = 0;
+    } else if (++idle_iterations >= kHttp3IdleIterations) {
+      break;
+    }
+  }
+}
+
+}  // namespace proto_fuzzer

--- a/proto_fuzzer/http3_mock_server.h
+++ b/proto_fuzzer/http3_mock_server.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+/// @file
+/// @brief Bounded ngtcp2/OpenSSL QUIC peer for HTTP/3 scenarios.
+
+#ifndef PROTO_FUZZER_HTTP3_MOCK_SERVER_H_
+#define PROTO_FUZZER_HTTP3_MOCK_SERVER_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "proto_fuzzer/mock_server_base.h"
+
+namespace proto_fuzzer {
+
+class Http3MockServerImpl;
+
+/// @class proto_fuzzer::Http3MockServer
+/// @brief In-process HTTP/3 server backed by ngtcp2 and OpenSSL TLS.
+///
+/// The peer uses a real nonblocking IPv4 UDP socket, negotiates TLS 1.3 and
+/// ALPN `h3`, and lets nghttp3 generate protocol-valid structured responses.
+/// Raw Http3StreamWrite actions deliberately bypass nghttp3 and write their
+/// bytes straight to an established QUIC stream. Open-unidirectional-stream
+/// actions additionally create an unbound stream whose first byte is entirely
+/// mutation-controlled. ngtcp2 applies QUIC framing and uses OpenSSL's EVP/TLS
+/// integration for encryption, so malformed HTTP/3/QPACK plaintext reaches
+/// curl only after a valid transport handshake.
+class Http3MockServer final : public MockServerBase {
+ public:
+  /// Construct a peer with the default checked-in EC certificate.
+  Http3MockServer();
+
+  /// Construct a peer with a bounded, parseable certificate-chain profile.
+  /// @param certificate_chain Certificate material presented during QUIC TLS.
+  explicit Http3MockServer(curl::fuzzer::proto::TlsCertificateChainProfile certificate_chain);
+
+  ~Http3MockServer() override;
+
+  Http3MockServer(const Http3MockServer&) = delete;
+  Http3MockServer& operator=(const Http3MockServer&) = delete;
+
+  /// Install UDP socket callbacks, the local trust anchor, and HTTP/3-only
+  /// negotiation on an easy handle.
+  /// @param easy Easy handle that will connect to the in-process QUIC peer.
+  void Install(CURL* easy) override;
+
+  /// @return true after the server has completed a QUIC TLS handshake.
+  bool handshake_complete() const;
+
+  /// @return true after nghttp3 has decoded a complete request field section.
+  bool request_headers_received() const;
+
+  /// @return number of ordered Http3Action entries accepted by the peer.
+  std::size_t executed_action_count() const;
+
+  /// @return kernel-selected UDP port in host byte order, or zero before use.
+  std::uint16_t server_port() const;
+
+ protected:
+  /// Create curl's real UDP descriptor and rewrite its destination to the
+  /// private loopback QUIC listener.
+  /// @param purpose Socket purpose supplied by curl's open-socket callback.
+  /// @param address Mutable destination description supplied by curl.
+  /// @return client UDP descriptor, or CURL_SOCKET_BAD on setup failure.
+  curl_socket_t HandleOpenSocket(curlsocktype purpose, struct curl_sockaddr* address) override;
+
+  /// Alternate nonblocking curl and QUIC server turns under fixed operation
+  /// and idle budgets.
+  /// @param multi Multi handle containing the scenario's easy handle.
+  /// @param easy Easy handle being driven; all work is reached through multi.
+  /// @param scenario Scenario whose Http3Plan supplies ordered plaintext work.
+  void RunLoop(CURLM* multi, CURL* easy, const curl::fuzzer::proto::Scenario& scenario) override;
+
+ private:
+  std::unique_ptr<Http3MockServerImpl> impl_;
+};
+
+}  // namespace proto_fuzzer
+
+#endif  // PROTO_FUZZER_HTTP3_MOCK_SERVER_H_

--- a/proto_fuzzer/scenario_limits.h
+++ b/proto_fuzzer/scenario_limits.h
@@ -11,6 +11,7 @@
 #define PROTO_FUZZER_SCENARIO_LIMITS_H_
 
 #include <cstddef>
+#include <cstdint>
 
 namespace proto_fuzzer::scenario_limits {
 
@@ -101,6 +102,33 @@ inline constexpr std::size_t kMaxMultiTransfers = 4;
 /// remove/re-add); sixteen permit several handles to interact without making
 /// action processing proportional to mutated protobuf size.
 inline constexpr std::size_t kMaxMultiActions = 16;
+/// Ordered H3 work needs enough slots to interleave response fragments with
+/// stream and connection state changes without becoming mutation-sized.
+inline constexpr std::size_t kMaxHttp3Actions = 16;
+/// Keep each structured header block small enough for cheap QPACK encoding.
+inline constexpr std::size_t kMaxHttp3Headers = 16;
+/// Trailer lists need fewer entries while retaining duplicate-name behavior.
+inline constexpr std::size_t kMaxHttp3Trailers = 8;
+/// Header names are tokens rather than general metadata. This comfortably
+/// exceeds practical field names while limiting canonicalization work.
+inline constexpr std::size_t kMaxHttp3HeaderNameBytes = 256;
+/// Values use the shared metadata ceiling used by other header-bearing APIs.
+inline constexpr std::size_t kMaxHttp3HeaderValueBytes = kMaxMetadataBytes;
+/// Share one metadata budget across every structured header and trailer block
+/// so many actions cannot multiply the per-field ceiling into a large case.
+inline constexpr std::size_t kMaxHttp3HeaderBytes = 16 * 1024;
+/// Bound the number of DATA-frame boundaries independently of total bytes.
+inline constexpr std::size_t kMaxHttp3BodyChunks = 16;
+/// A response body can still cross curl's normal 16 KiB callback boundary.
+inline constexpr std::size_t kMaxHttp3BodyBytes = 16 * 1024;
+/// Raw plaintext is primarily for malformed frame/QPACK prefixes; a compact
+/// per-action cap preserves that purpose without duplicating body storage.
+inline constexpr std::size_t kMaxHttp3RawWriteBytes = 4 * 1024;
+/// Share one ceiling across all raw actions so sixteen maximum-sized writes
+/// cannot make one fuzzer iteration disproportionately expensive.
+inline constexpr std::size_t kMaxHttp3RawBytes = 16 * 1024;
+/// QUIC variable-length integers reserve their two high bits for encoding.
+inline constexpr std::uint64_t kMaxQuicVarint = (std::uint64_t{1} << 62U) - 1U;
 
 }  // namespace proto_fuzzer::scenario_limits
 

--- a/proto_fuzzer/scenario_runner.cc
+++ b/proto_fuzzer/scenario_runner.cc
@@ -32,6 +32,9 @@
 #include "proto_fuzzer/h2_proxy_mock_server.h"
 #include "proto_fuzzer/tls_mock_server.h"
 #endif
+#if defined(PROTO_FUZZER_HAS_HTTP3_MOCK_SERVER)
+#include "proto_fuzzer/http3_mock_server.h"
+#endif
 
 namespace proto_fuzzer {
 
@@ -104,6 +107,14 @@ const char* SchemePrefix(curl::fuzzer::proto::Scheme scheme) {
 /// protobuf field from silently changing old OSS-Fuzz reproducers.
 std::unique_ptr<MockServerBase> MakeMockServerForScenario(const curl::fuzzer::proto::Scenario& scenario,
                                                           ScenarioRunMode mode) {
+  if (mode == ScenarioRunMode::kHttp3Coverage) {
+#if defined(PROTO_FUZZER_HAS_HTTP3_MOCK_SERVER)
+    return std::make_unique<Http3MockServer>(scenario.tls_certificate_chain());
+#else
+    return nullptr;
+#endif
+  }
+
   if (mode == ScenarioRunMode::kH2ProxyCoverage) {
 #if defined(PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
     return std::make_unique<H2ProxyMockServer>();
@@ -240,8 +251,10 @@ int ScenarioRunner::Run(const curl::fuzzer::proto::Scenario& scenario, ScenarioR
     if (drive_mode == curl::fuzzer::proto::API_DRIVE_EASY_PERFORM) {
       mock->DriveEasyScenario(easy.get(), scenario);
     } else {
-      mock->DriveScenario(easy.get(), scenario, drive_mode == curl::fuzzer::proto::API_DRIVE_MULTI_SOCKET,
-                          api_plan != nullptr && api_plan->wake_multi());
+      mock->DriveScenario(
+          easy.get(), scenario,
+          mode == ScenarioRunMode::kHttp3Coverage || drive_mode == curl::fuzzer::proto::API_DRIVE_MULTI_SOCKET,
+          api_plan != nullptr && api_plan->wake_multi());
     }
     if (api_lifecycle != nullptr) {
       api_lifecycle->ProbeTransferResults(drive_mode == curl::fuzzer::proto::API_DRIVE_EASY_PERFORM);

--- a/proto_fuzzer/target_policy.cc
+++ b/proto_fuzzer/target_policy.cc
@@ -66,6 +66,19 @@ void CanonicalizeTlsAuthority(curl::fuzzer::proto::Scenario* scenario) {
   scenario->set_host_path("tls.test" + host_path.substr(suffix_start));
 }
 
+/// Both fixed TLS peers support the same closed set of checked-in certificate
+/// bundles. Unknown proto3 enum values fall back to the historical EC chain.
+void CanonicalizeTlsCertificateChain(curl::fuzzer::proto::Scenario* scenario) {
+  switch (scenario->tls_certificate_chain()) {
+    case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC:
+    case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES:
+      return;
+    default:
+      scenario->clear_tls_certificate_chain();
+      return;
+  }
+}
+
 /// Keep the tunneled origin parseable while retaining every path, query, and
 /// fragment byte. The fixed numeric proxy endpoint handles routing separately;
 /// mutating the origin authority would therefore buy only early URL failures,
@@ -292,6 +305,181 @@ void BoundMultiPlanShape(curl::fuzzer::proto::MultiPlan* plan) {
   }
 }
 
+/// HTTP field names are lowercase RFC token bytes in the structured lane.
+/// Replacing (rather than deleting) invalid bytes retains mutation-significant
+/// positions while preventing accidental pseudo-headers and encoder failures.
+void CanonicalizeHttp3HeaderName(std::string* name) {
+  if (name->size() > scenario_limits::kMaxHttp3HeaderNameBytes) {
+    name->resize(scenario_limits::kMaxHttp3HeaderNameBytes);
+  }
+  if (name->empty()) {
+    *name = "x-fuzz";
+    return;
+  }
+
+  for (char& byte : *name) {
+    const unsigned char value = static_cast<unsigned char>(byte);
+    const bool alpha = (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z');
+    const bool digit = value >= '0' && value <= '9';
+    const bool punctuation = value == '!' || value == '#' || value == '$' || value == '%' || value == '&' ||
+                             value == '\'' || value == '*' || value == '+' || value == '-' || value == '.' ||
+                             value == '^' || value == '_' || value == '`' || value == '|' || value == '~';
+    if (value >= 'A' && value <= 'Z') {
+      byte = static_cast<char>(value - 'A' + 'a');
+    } else if (!alpha && !digit && !punctuation) {
+      byte = '-';
+    }
+  }
+}
+
+/// Structured field values must not inject another HTTP field or carry NUL
+/// into the encoder. Observable malformed bytes remain available in raw stream
+/// actions, while this path stays suitable for valid QPACK generation.
+void CanonicalizeHttp3HeaderValue(std::string* value) {
+  if (value->size() > scenario_limits::kMaxHttp3HeaderValueBytes) {
+    value->resize(scenario_limits::kMaxHttp3HeaderValueBytes);
+  }
+  for (char& byte : *value) {
+    const unsigned char character = static_cast<unsigned char>(byte);
+    if ((character < 0x20U && character != '\t') || character == 0x7fU) {
+      byte = ' ';
+    }
+  }
+}
+
+/// Retain only a prefix of encodable fields within both a count and a shared
+/// byte budget. A missing name is materialized as x-fuzz while budget remains,
+/// making default-initialized structured headers useful to the peer.
+template <typename RepeatedHeaders>
+void BoundHttp3Headers(RepeatedHeaders* headers, std::size_t count_limit, std::size_t* remaining_bytes) {
+  TrimRepeated(headers, count_limit);
+  std::size_t retained = 0;
+  while (retained < static_cast<std::size_t>(headers->size()) && *remaining_bytes != 0) {
+    auto* header = headers->Mutable(static_cast<int>(retained));
+    CanonicalizeHttp3HeaderName(header->mutable_name());
+    CanonicalizeHttp3HeaderValue(header->mutable_value());
+
+    if (header->name().size() > *remaining_bytes) {
+      header->mutable_name()->resize(*remaining_bytes);
+      header->clear_value();
+    } else if (header->value().size() > *remaining_bytes - header->name().size()) {
+      header->mutable_value()->resize(*remaining_bytes - header->name().size());
+    }
+    *remaining_bytes -= header->name().size() + header->value().size();
+    ++retained;
+  }
+  TrimRepeated(headers, retained);
+}
+
+void CanonicalizeHttp3StreamRole(curl::fuzzer::proto::Http3StreamRole* role) {
+  switch (*role) {
+    case curl::fuzzer::proto::HTTP3_STREAM_RESPONSE:
+    case curl::fuzzer::proto::HTTP3_STREAM_CONTROL:
+    case curl::fuzzer::proto::HTTP3_STREAM_QPACK_ENCODER:
+    case curl::fuzzer::proto::HTTP3_STREAM_QPACK_DECODER:
+      return;
+    default:
+      *role = curl::fuzzer::proto::HTTP3_STREAM_RESPONSE;
+      return;
+  }
+}
+
+void BoundHttp3RawData(std::string* data, std::size_t* remaining_raw_bytes) {
+  const std::size_t limit = std::min(scenario_limits::kMaxHttp3RawWriteBytes, *remaining_raw_bytes);
+  if (data->size() > limit) {
+    data->resize(limit);
+  }
+  *remaining_raw_bytes -= data->size();
+}
+
+/// Canonicalize one ordered H3 script to the exact bounded prefix that the
+/// QUIC peer can execute. Transport setup remains peer-owned; only plaintext
+/// HTTP/3 operations are mutation-controlled here.
+void BoundHttp3PlanShape(curl::fuzzer::proto::Http3Plan* plan) {
+  TrimRepeated(plan->mutable_actions(), scenario_limits::kMaxHttp3Actions);
+  if (plan->actions().empty()) {
+    auto* response = plan->add_actions()->mutable_structured_response();
+    response->set_status_code(200);
+    response->set_finish_stream(true);
+  }
+
+  std::size_t remaining_header_bytes = scenario_limits::kMaxHttp3HeaderBytes;
+  std::size_t remaining_body_bytes = scenario_limits::kMaxHttp3BodyBytes;
+  std::size_t remaining_raw_bytes = scenario_limits::kMaxHttp3RawBytes;
+  std::size_t retained_actions = 0;
+  bool connection_closed = false;
+  for (auto& action : *plan->mutable_actions()) {
+    if (connection_closed) {
+      break;
+    }
+    ++retained_actions;
+    switch (action.action_case()) {
+      case curl::fuzzer::proto::Http3Action::kStructuredResponse: {
+        auto* response = action.mutable_structured_response();
+        if (response->status_code() == 0U) {
+          response->set_status_code(200U);
+        } else if (response->status_code() < 100U || response->status_code() > 599U) {
+          response->set_status_code(100U + response->status_code() % 500U);
+        }
+        BoundHttp3Headers(response->mutable_response_headers(), scenario_limits::kMaxHttp3Headers,
+                          &remaining_header_bytes);
+        BoundHttp3Headers(response->mutable_response_trailers(), scenario_limits::kMaxHttp3Trailers,
+                          &remaining_header_bytes);
+        TrimRepeated(response->mutable_body_chunks(), scenario_limits::kMaxHttp3BodyChunks);
+        for (std::string& chunk : *response->mutable_body_chunks()) {
+          if (chunk.size() > remaining_body_bytes) {
+            chunk.resize(remaining_body_bytes);
+          }
+          remaining_body_bytes -= chunk.size();
+        }
+        break;
+      }
+
+      case curl::fuzzer::proto::Http3Action::kStreamWrite: {
+        auto* write = action.mutable_stream_write();
+        auto role = write->role();
+        CanonicalizeHttp3StreamRole(&role);
+        write->set_role(role);
+        BoundHttp3RawData(write->mutable_data(), &remaining_raw_bytes);
+        break;
+      }
+
+      case curl::fuzzer::proto::Http3Action::kOpenUnidirectionalStream: {
+        auto* stream = action.mutable_open_unidirectional_stream();
+        BoundHttp3RawData(stream->mutable_data(), &remaining_raw_bytes);
+        break;
+      }
+
+      case curl::fuzzer::proto::Http3Action::kStreamReset: {
+        auto* reset = action.mutable_stream_reset();
+        auto role = reset->role();
+        CanonicalizeHttp3StreamRole(&role);
+        reset->set_role(role);
+        reset->set_application_error_code(reset->application_error_code() & scenario_limits::kMaxQuicVarint);
+        break;
+      }
+
+      case curl::fuzzer::proto::Http3Action::kGoaway:
+        action.mutable_goaway()->set_id(action.goaway().id() & scenario_limits::kMaxQuicVarint & ~std::uint64_t{3});
+        break;
+
+      case curl::fuzzer::proto::Http3Action::kConnectionClose:
+        action.mutable_connection_close()->set_application_error_code(
+            action.connection_close().application_error_code() & scenario_limits::kMaxQuicVarint);
+        connection_closed = true;
+        break;
+
+      case curl::fuzzer::proto::Http3Action::ACTION_NOT_SET: {
+        auto* response = action.mutable_structured_response();
+        response->set_status_code(200);
+        response->set_finish_stream(true);
+        break;
+      }
+    }
+  }
+  TrimRepeated(plan->mutable_actions(), retained_actions);
+}
+
 /// Canonicalize all shape limits enforced by the runtime. This runs only in
 /// fixed policy targets; the compatibility binary deliberately retains its
 /// historical no-postprocessor semantics for existing OSS-Fuzz reproducers.
@@ -457,6 +645,14 @@ void RetainCheapHttpOptions(curl::fuzzer::proto::Scenario* scenario) {
 /// Compact the option list before its shared cap so irrelevant TLS, WebSocket,
 /// and file-transfer entries cannot crowd out origin traffic mutations.
 void RetainH2ProxyOriginOptions(curl::fuzzer::proto::Scenario* scenario) {
+  RetainMatchingOptions(scenario, &IsH2ProxyOriginOption);
+}
+
+/// HTTP/3 owns QUIC selection, ALPN, routing, and certificate verification in
+/// its peer. The tunneled-origin allowlist is deliberately the same set of
+/// request-level HTTP controls, and notably excludes CURLOPT_HTTP_VERSION and
+/// CURLOPT_CONNECT_ONLY, which could bypass the dedicated transport.
+void RetainHttp3RequestOptions(curl::fuzzer::proto::Scenario* scenario) {
   RetainMatchingOptions(scenario, &IsH2ProxyOriginOption);
 }
 
@@ -712,6 +908,17 @@ void RemoveApiOnlyShape(curl::fuzzer::proto::Scenario* scenario) { scenario->cle
 /// compatibility binary deliberately preserves newly-added unknown fields.
 void RemoveMultiOnlyShape(curl::fuzzer::proto::Scenario* scenario) { scenario->clear_multi_plan(); }
 
+/// The QUIC peer consumes Http3Plan rather than the stream-socket response
+/// script. Request headers, MIME, upload state, and HTTP options remain useful
+/// because curl serializes those onto its client-initiated request stream.
+void RemoveIgnoredHttp3Shape(curl::fuzzer::proto::Scenario* scenario) {
+  scenario->clear_connection();
+  scenario->clear_subsequent_connections();
+  RemoveTelnetOnlyShape(scenario);
+  RemoveApiOnlyShape(scenario);
+  RemoveMultiOnlyShape(scenario);
+}
+
 /// Remove stream-driver controls that neither file-transfer peer interprets.
 /// FTP consumes raw byte chunks as control/data replies, while TFTP preserves
 /// them as individual datagrams; structured WebSocket frames, manual probes,
@@ -831,11 +1038,31 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     return;
   }
 
-  // Only the dedicated HTTPS peer consumes a certificate-chain selector.
-  // Remove it before protocol-specific early returns so other fixed targets
-  // do not spend mutations on inert TLS server state.
-  if (profile != TargetProfile::kFastHttps) {
+  // Only the dedicated TLS and QUIC peers consume a certificate-chain
+  // selector. Remove it before protocol-specific early returns so other fixed
+  // targets do not spend mutations on inert TLS server state.
+  if (profile != TargetProfile::kFastHttps && profile != TargetProfile::kFastHttp3) {
     scenario->clear_tls_certificate_chain();
+  }
+
+  // Field 13 is append-only so the compatibility target can round-trip it,
+  // but every other fixed lane must discard work its peer cannot consume.
+  if (profile != TargetProfile::kFastHttp3) {
+    scenario->clear_http3_plan();
+  }
+
+  if (profile == TargetProfile::kFastHttp3) {
+    scenario->set_scheme(curl::fuzzer::proto::SCHEME_HTTPS);
+    RemoveIgnoredHttp3Shape(scenario);
+    RetainHttp3RequestOptions(scenario);
+    BoundScenarioShape(scenario);
+    // BoundScenarioShape materializes an empty primary Connection while
+    // sharing request-side limits. Do not retain that protocol-inert message.
+    scenario->clear_connection();
+    BoundHttp3PlanShape(scenario->mutable_http3_plan());
+    CanonicalizeTlsAuthority(scenario);
+    CanonicalizeTlsCertificateChain(scenario);
+    return;
   }
 
   if (profile == TargetProfile::kFastTelnet) {
@@ -913,6 +1140,9 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     case TargetProfile::kFastHttps:
       scenario->set_scheme(curl::fuzzer::proto::SCHEME_HTTPS);
       break;
+    case TargetProfile::kFastHttp3:
+      // The protocol-specific early path owns the QUIC response plan.
+      return;
     case TargetProfile::kH2Proxy:
       // The early path removes proxy-incompatible fields before general
       // bounds, keeping raw frame mutation dense.
@@ -982,14 +1212,12 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     case TargetProfile::kFastHttps:
       ClearAllBackpressure(scenario);
       CanonicalizeTlsAuthority(scenario);
-      switch (scenario->tls_certificate_chain()) {
-        case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC:
-        case curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES:
-          break;
-        default:
-          scenario->clear_tls_certificate_chain();
-          break;
-      }
+      CanonicalizeTlsCertificateChain(scenario);
+      return;
+
+    case TargetProfile::kFastHttp3:
+      // Handled before generic connection bounding because Http3Plan replaces
+      // the stream-socket response script.
       return;
 
     case TargetProfile::kH2Proxy:

--- a/proto_fuzzer/target_profile.h
+++ b/proto_fuzzer/target_profile.h
@@ -24,6 +24,8 @@ enum class TargetProfile {
   kDeepHttp,
   /// Exercise a complete HTTPS exchange against the in-process TLS peer.
   kFastHttps,
+  /// Exercise HTTP/3 over a valid in-process QUIC/TLS connection.
+  kFastHttp3,
   /// Exercise an HTTP/1.1 origin through an HTTPS/HTTP2 CONNECT proxy.
   kH2Proxy,
   /// Exercise plaintext WebSocket framing without wall-clock waits.
@@ -53,6 +55,8 @@ enum class ScenarioRunMode {
   kProtocolCoverage,
   /// Drive HTTPS through a real TLS peer and inspect live TLS result state.
   kTlsCoverage,
+  /// Drive ordered plaintext HTTP/3 actions through the QUIC peer.
+  kHttp3Coverage,
   /// Drive raw HTTP/2 proxy frames around one CONNECT tunnel.
   kH2ProxyCoverage,
   /// Drive FTP through its concurrent control/passive-data peer.
@@ -84,6 +88,9 @@ constexpr ScenarioRunMode RunModeFor(TargetProfile profile) {
 
     case TargetProfile::kFastHttps:
       return ScenarioRunMode::kTlsCoverage;
+
+    case TargetProfile::kFastHttp3:
+      return ScenarioRunMode::kHttp3Coverage;
 
     case TargetProfile::kH2Proxy:
       return ScenarioRunMode::kH2ProxyCoverage;

--- a/scenarios/curl_fuzzer_proto/http3/http3_basic_response.textproto
+++ b/scenarios/curl_fuzzer_proto/http3/http3_basic_response.textproto
@@ -1,0 +1,23 @@
+# Keep the first H3 corpus entry entirely structured so every run starts from
+# a valid QUIC/TLS connection, QPACK block, DATA frame, trailers, and FIN.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/basic"
+request_headers: "Accept: */*"
+http3_plan {
+  actions {
+    structured_response {
+      status_code: 200
+      response_headers {
+        name: "content-type"
+        value: "text/plain"
+      }
+      body_chunks: "hello "
+      body_chunks: "over h3"
+      response_trailers {
+        name: "x-fuzz-trailer"
+        value: "complete"
+      }
+      finish_stream: true
+    }
+  }
+}

--- a/scenarios/curl_fuzzer_proto/http3/http3_control_error.textproto
+++ b/scenarios/curl_fuzzer_proto/http3/http3_control_error.textproto
@@ -1,0 +1,19 @@
+# Start from a valid request/response, then append a second SETTINGS frame to
+# the peer control stream. HTTP/3 forbids duplicate SETTINGS, giving mutation
+# a compact route into curl/nghttp3 control-stream error handling.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/control-error"
+http3_plan {
+  actions {
+    structured_response {
+      status_code: 200
+      body_chunks: "control"
+    }
+  }
+  actions {
+    stream_write {
+      role: HTTP3_STREAM_CONTROL
+      data: "\x04\x00"
+    }
+  }
+}

--- a/scenarios/curl_fuzzer_proto/http3/http3_duplicate_control_stream.textproto
+++ b/scenarios/curl_fuzzer_proto/http3/http3_duplicate_control_stream.textproto
@@ -1,0 +1,14 @@
+# Open a second server control stream from byte zero. HTTP/3 permits exactly
+# one control stream in each direction, so this seed reaches curl/nghttp3's
+# duplicate-critical-stream handling without corrupting the valid bootstrap.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/duplicate-control-stream"
+http3_plan {
+  actions {
+    open_unidirectional_stream {
+      # stream type=control, followed by an empty SETTINGS frame.
+      data: "\x00\x04\x00"
+      finish_stream: true
+    }
+  }
+}

--- a/scenarios/curl_fuzzer_proto/http3/http3_ordered_shutdown.textproto
+++ b/scenarios/curl_fuzzer_proto/http3/http3_ordered_shutdown.textproto
@@ -1,0 +1,33 @@
+# Exercise informational/final response ordering and each peer-owned shutdown
+# operation without asking mutations to synthesize a QUIC or TLS handshake.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/shutdown"
+http3_plan {
+  actions {
+    structured_response {
+      status_code: 103
+      response_headers {
+        name: "link"
+        value: "</asset>; rel=preload"
+      }
+    }
+  }
+  actions {
+    structured_response {
+      status_code: 200
+      body_chunks: "partial body"
+    }
+  }
+  actions {
+    stream_reset {
+      role: HTTP3_STREAM_RESPONSE
+      application_error_code: 268
+    }
+  }
+  actions {
+    goaway { id: 0 }
+  }
+  actions {
+    connection_close { application_error_code: 256 }
+  }
+}

--- a/scenarios/curl_fuzzer_proto/http3/http3_qpack_instructions.textproto
+++ b/scenarios/curl_fuzzer_proto/http3/http3_qpack_instructions.textproto
@@ -1,0 +1,24 @@
+# Exercise both QPACK instruction parsers after their critical streams have
+# valid type prefixes. Exact suffix bytes remain freely mutable.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/qpack"
+http3_plan {
+  actions {
+    structured_response {
+      status_code: 200
+      body_chunks: "qpack"
+    }
+  }
+  actions {
+    stream_write {
+      role: HTTP3_STREAM_QPACK_ENCODER
+      data: "\xff\x00"
+    }
+  }
+  actions {
+    stream_write {
+      role: HTTP3_STREAM_QPACK_DECODER
+      data: "\xff\x00"
+    }
+  }
+}

--- a/scenarios/curl_fuzzer_proto/http3/http3_raw_response.textproto
+++ b/scenarios/curl_fuzzer_proto/http3/http3_raw_response.textproto
@@ -1,0 +1,14 @@
+# Drive the complete response stream as exact mutator-controlled plaintext.
+# HEADERS carries a zero-state QPACK block with static :status=200; DATA then
+# supplies the body before FIN. Mutations can replace every H3 response byte.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/raw-complete"
+http3_plan {
+  actions {
+    stream_write {
+      role: HTTP3_STREAM_RESPONSE
+      data: "\x01\x03\x00\x00\xd9\x00\x09raw-first"
+      finish_stream: true
+    }
+  }
+}

--- a/scenarios/curl_fuzzer_proto/http3/http3_raw_response_suffix.textproto
+++ b/scenarios/curl_fuzzer_proto/http3/http3_raw_response_suffix.textproto
@@ -1,0 +1,23 @@
+# Structured headers establish a valid response before a raw plaintext frame
+# prefix probes nghttp3/curl error handling on the same request stream.
+scheme: SCHEME_HTTPS
+host_path: "tls.test/raw"
+http3_plan {
+  actions {
+    structured_response {
+      status_code: 200
+      response_headers {
+        name: "content-type"
+        value: "application/octet-stream"
+      }
+    }
+  }
+  actions {
+    stream_write {
+      role: HTTP3_STREAM_RESPONSE
+      # Unknown frame type 0x21, two-byte payload, followed by FIN.
+      data: "\x21\x02\xde\xad"
+      finish_stream: true
+    }
+  }
+}

--- a/schemas/curl_fuzzer.proto
+++ b/schemas/curl_fuzzer.proto
@@ -78,6 +78,12 @@ message Scenario {
   // choice a parseable TLS handshake while still varying the X509 public-key
   // types consumed by curl. Other fixed protocol lanes discard this field.
   TlsCertificateChainProfile tls_certificate_chain = 12;
+  // Ordered HTTP/3 peer work for the dedicated QUIC lane. Keeping this in a
+  // separate message lets the ordinary Connection retain its historical
+  // stream-socket meaning while the H3 peer encrypts these plaintext actions
+  // onto the appropriate QUIC streams. Non-H3 fixed targets discard the plan;
+  // the compatibility target deliberately leaves field 13 untouched.
+  Http3Plan http3_plan = 13;
 }
 
 // Test-only certificate bundles available to the in-process TLS server. Zero
@@ -86,6 +92,89 @@ message Scenario {
 enum TlsCertificateChainProfile {
   TLS_CERTIFICATE_CHAIN_DEFAULT_EC = 0;
   TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES = 1;
+}
+
+// A bounded, ordered HTTP/3 server script. Structured responses keep common
+// mutations protocol-valid; raw writes retain access to malformed HTTP/3 and
+// QPACK input after the peer has completed a valid QUIC/TLS handshake.
+message Http3Plan {
+  repeated Http3Action actions = 1;
+}
+
+// One operation performed by the in-process HTTP/3 peer. The oneof prevents a
+// mutation from describing contradictory response and termination work while
+// still permitting deliberate ordering such as response, GOAWAY, then FIN.
+message Http3Action {
+  oneof action {
+    Http3Response structured_response = 1;
+    Http3StreamWrite stream_write = 2;
+    Http3StreamReset stream_reset = 3;
+    Http3Goaway goaway = 4;
+    Http3ConnectionClose connection_close = 5;
+    Http3OpenUnidirectionalStream open_unidirectional_stream = 6;
+  }
+}
+
+// A response encoded by the peer through nghttp3. Status is canonicalized to
+// 100..599, header metadata and chunk counts are bounded, and finish_stream
+// controls whether this response also concludes the request stream.
+message Http3Response {
+  uint32 status_code = 1;
+  repeated Http3Header response_headers = 2;
+  repeated bytes body_chunks = 3;
+  repeated Http3Header response_trailers = 4;
+  bool finish_stream = 5;
+}
+
+// One ordinary response or trailer field. Pseudo-headers are peer-owned; the
+// policy turns names into lowercase HTTP token bytes so this structured path
+// remains encodable. Malformed fields remain reachable through raw writes.
+message Http3Header {
+  bytes name = 1;
+  bytes value = 2;
+}
+
+// Streams writable by an HTTP/3 server. Zero intentionally names the response
+// stream so a default-initialized action remains useful.
+enum Http3StreamRole {
+  HTTP3_STREAM_RESPONSE = 0;
+  HTTP3_STREAM_CONTROL = 1;
+  HTTP3_STREAM_QPACK_ENCODER = 2;
+  HTTP3_STREAM_QPACK_DECODER = 3;
+}
+
+// Plaintext bytes written after QUIC/TLS has made the selected stream live.
+// Setting finish_stream makes the write and stream conclusion one ordered
+// operation; an empty write can therefore express a standalone FIN.
+message Http3StreamWrite {
+  Http3StreamRole role = 1;
+  bytes data = 2;
+  bool finish_stream = 3;
+}
+
+// Create a fresh server-initiated unidirectional QUIC stream and write these
+// exact plaintext bytes from stream offset zero. Unlike a role-based write,
+// the peer does not prepend a stream type or bind the stream to nghttp3, so
+// mutations can select unknown and duplicate HTTP/3 stream types directly.
+message Http3OpenUnidirectionalStream {
+  bytes data = 1;
+  bool finish_stream = 2;
+}
+
+message Http3StreamReset {
+  Http3StreamRole role = 1;
+  uint64 application_error_code = 2;
+}
+
+message Http3Goaway {
+  // Client-initiated bidirectional stream ID advertised as the first request
+  // the server will reject. The target policy folds this onto 0,4,8,... and
+  // into QUIC's 62-bit varint range.
+  uint64 id = 1;
+}
+
+message Http3ConnectionClose {
+  uint64 application_error_code = 1;
 }
 
 // A bounded plan for public libcurl APIs that are adjacent to, rather than

--- a/scripts/compare_fuzzers.py
+++ b/scripts/compare_fuzzers.py
@@ -42,6 +42,7 @@ DEFAULT_TARGETS = (
     "curl_fuzzer_proto_https",
     "curl_fuzzer_proto_https_gnutls",
     "curl_fuzzer_proto_https_mbedtls",
+    "curl_fuzzer_proto_http3",
     "curl_fuzzer_proto_h2_proxy",
     "curl_fuzzer_proto_ws",
     "curl_fuzzer_proto_wss",
@@ -55,6 +56,7 @@ DEFAULT_TARGETS = (
 COMPATIBLE_CORPUS_TARGETS = {
     "curl_fuzzer_proto_https_gnutls": ("curl_fuzzer_proto_https",),
     "curl_fuzzer_proto_https_mbedtls": ("curl_fuzzer_proto_https",),
+    "curl_fuzzer_proto_http3": ("curl_fuzzer_proto_https",),
 }
 HISTORICAL_PROTO_CORPUS_TARGETS = frozenset(
     {
@@ -63,6 +65,7 @@ HISTORICAL_PROTO_CORPUS_TARGETS = frozenset(
         "curl_fuzzer_proto_https",
         "curl_fuzzer_proto_https_gnutls",
         "curl_fuzzer_proto_https_mbedtls",
+        "curl_fuzzer_proto_http3",
         "curl_fuzzer_proto_ws",
         "curl_fuzzer_proto_wss",
         "curl_fuzzer_proto_telnet",

--- a/scripts/fuzz_corpus_helpers.sh
+++ b/scripts/fuzz_corpus_helpers.sh
@@ -47,6 +47,13 @@ fuzz_public_corpus_names() {
             echo "curl_fuzzer_proto_https"
             echo "curl_fuzzer_proto"
             ;;
+        curl_fuzzer_proto_http3)
+            # HTTP/3 has its own wire-response seeds, but ordinary HTTPS
+            # scenarios still provide useful URL, request, and option state;
+            # the fixed profile supplies a valid default H3 response plan.
+            echo "curl_fuzzer_proto_https"
+            echo "curl_fuzzer_proto"
+            ;;
         curl_fuzzer_proto_http|curl_fuzzer_proto_http_deep|curl_fuzzer_proto_https|curl_fuzzer_proto_ws|curl_fuzzer_proto_wss|curl_fuzzer_proto_telnet|curl_fuzzer_proto_ftp|curl_fuzzer_proto_tftp|curl_fuzzer_proto_api|curl_fuzzer_proto_multi|curl_fuzzer_proto_timing)
             echo "curl_fuzzer_proto"
             ;;

--- a/scripts/fuzz_targets
+++ b/scripts/fuzz_targets
@@ -9,7 +9,7 @@ if [ "${ARCHITECTURE:-}" != "i386" ]; then
     # MemorySanitizer until all of their static dependencies can be built with
     # MSan instrumentation.
     if [ "${SANITIZER:-}" != "memory" ]; then
-        FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto_https_gnutls curl_fuzzer_proto_https_mbedtls"
+        FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto_https_gnutls curl_fuzzer_proto_https_mbedtls curl_fuzzer_proto_http3"
     fi
 fi
 

--- a/scripts/trim_cache.sh
+++ b/scripts/trim_cache.sh
@@ -103,7 +103,7 @@ for install_dir in "${BD}"/*-install; do
     continue
   fi
   case "${install_name}" in
-    curl-install|curl-gnutls-install|curl-mbedtls-install|lpm-*-install|gdb-*-install)
+    curl-install|curl-gnutls-install|curl-mbedtls-install|curl-http3-install|lpm-*-install|gdb-*-install)
       continue
       ;;
   esac

--- a/tests/curl_features_test.cc
+++ b/tests/curl_features_test.cc
@@ -83,6 +83,18 @@ int main() {
     return 1;
   }
 #endif
+#ifdef CURL_FUZZER_EXPECT_HTTP3
+  if (!(info->features & CURL_VERSION_HTTP3)) {
+    std::fputs("libcurl was built without HTTP/3 support\n", stderr);
+    return 1;
+  }
+  if (!info->quic_version ||
+      std::strstr(info->quic_version, "ngtcp2/") == nullptr ||
+      std::strstr(info->quic_version, "nghttp3/") == nullptr) {
+    std::fputs("libcurl does not report the ngtcp2/nghttp3 stack\n", stderr);
+    return 1;
+  }
+#endif
 #if defined(CURL_FUZZER_EXPECT_HTTPSRR) || \
     defined(CURL_FUZZER_EXPECT_OPENSSL_EXPERIMENTAL_FEATURES)
   if (!HasNamedFeature(info, "HTTPSRR")) {

--- a/tests/http3_mock_server_test.cc
+++ b/tests/http3_mock_server_test.cc
@@ -1,0 +1,241 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include <curl/curl.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "curl_fuzzer.pb.h"
+#include "proto_fuzzer/curl_raii.h"
+#include "proto_fuzzer/http3_mock_server.h"
+#include "proto_fuzzer/option_apply.h"
+#include "proto_fuzzer/request_data.h"
+
+namespace {
+
+using curl::fuzzer::proto::Scenario;
+using proto_fuzzer::CurlEasyPtr;
+using proto_fuzzer::CurlSlistPtr;
+
+void Fail(const char *message) {
+  std::cerr << message << '\n';
+  std::exit(1);
+}
+
+void Expect(bool condition, const char *message) {
+  if (!condition) {
+    Fail(message);
+  }
+}
+
+std::size_t CollectBytes(char *contents, std::size_t size, std::size_t nmemb,
+                         void *userdata) {
+  const std::size_t bytes = size * nmemb;
+  static_cast<std::string *>(userdata)->append(contents, bytes);
+  return bytes;
+}
+
+struct Http3RunResult {
+  CURLcode code = CURLE_FAILED_INIT;
+  std::string body;
+  std::string headers;
+  long response_code = 0;
+  long http_version = CURL_HTTP_VERSION_NONE;
+  bool handshake_complete = false;
+  bool request_headers_received = false;
+  std::size_t executed_action_count = 0;
+  std::uint16_t server_port = 0;
+};
+
+Http3RunResult RunScenario(const Scenario &scenario, const char *path) {
+  Http3RunResult result;
+  CurlEasyPtr easy(curl_easy_init());
+  Expect(easy != nullptr, "curl_easy_init failed");
+  CurlSlistPtr connect_to(proto_fuzzer::ApplyBaselineOptions(
+      easy.get(), curl::fuzzer::proto::SCHEME_HTTPS));
+  Expect(connect_to != nullptr,
+         "HTTP/3 baseline did not create CONNECT_TO state");
+
+  const std::string url = std::string("https://tls.test/") + path;
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_URL, url.c_str()) == CURLE_OK,
+         "HTTP/3 URL setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_WRITEFUNCTION, &CollectBytes) ==
+             CURLE_OK,
+         "HTTP/3 write callback setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_WRITEDATA, &result.body) ==
+             CURLE_OK,
+         "HTTP/3 write data setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_HEADERFUNCTION, &CollectBytes) ==
+             CURLE_OK,
+         "HTTP/3 header callback setup failed");
+  Expect(curl_easy_setopt(easy.get(), CURLOPT_HEADERDATA, &result.headers) ==
+             CURLE_OK,
+         "HTTP/3 header data setup failed");
+  (void)proto_fuzzer::ApplyScenarioOptions(easy.get(), scenario);
+
+  proto_fuzzer::Http3MockServer server(scenario.tls_certificate_chain());
+  server.Install(easy.get());
+  {
+    proto_fuzzer::ScenarioRequestData request_data(easy.get(), scenario);
+    result.code = server.DriveScenario(easy.get(), scenario, true);
+  }
+  (void)curl_easy_getinfo(easy.get(), CURLINFO_RESPONSE_CODE,
+                          &result.response_code);
+  (void)curl_easy_getinfo(easy.get(), CURLINFO_HTTP_VERSION,
+                          &result.http_version);
+  result.handshake_complete = server.handshake_complete();
+  result.request_headers_received = server.request_headers_received();
+  result.executed_action_count = server.executed_action_count();
+  result.server_port = server.server_port();
+
+  // Pointer-valued baseline options must outlive easy cleanup.
+  easy.reset();
+  connect_to.reset();
+  return result;
+}
+
+void TestStructuredResponseWithTrailers() {
+  Scenario scenario;
+  auto *action = scenario.mutable_http3_plan()->add_actions();
+  auto *response = action->mutable_structured_response();
+  response->set_status_code(200);
+  auto *header = response->add_response_headers();
+  header->set_name("content-type");
+  header->set_value("text/plain");
+  response->add_body_chunks("hello ");
+  response->add_body_chunks("http3");
+  auto *trailer = response->add_response_trailers();
+  trailer->set_name("x-h3-trailer");
+  trailer->set_value("complete");
+  response->set_finish_stream(true);
+
+  const Http3RunResult result = RunScenario(scenario, "structured");
+  if (result.code != CURLE_OK) {
+    std::cerr << "structured HTTP/3 CURLcode " << result.code << ": "
+              << curl_easy_strerror(result.code)
+              << ", handshake=" << result.handshake_complete
+              << ", request_headers=" << result.request_headers_received
+              << ", actions=" << result.executed_action_count
+              << ", port=" << result.server_port << '\n';
+  }
+  Expect(result.code == CURLE_OK,
+         "structured HTTP/3 transfer did not complete");
+  Expect(result.response_code == 200,
+         "structured HTTP/3 response did not report status 200");
+  Expect(result.http_version == CURL_HTTP_VERSION_3,
+         "structured transfer did not use HTTP/3");
+  Expect(result.body == "hello http3",
+         "structured HTTP/3 response produced the wrong body");
+  Expect(result.headers.find("x-h3-trailer: complete") != std::string::npos,
+         "structured HTTP/3 response did not deliver its trailer");
+  Expect(result.handshake_complete,
+         "HTTP/3 server did not complete its QUIC TLS handshake");
+  Expect(result.request_headers_received,
+         "HTTP/3 server did not decode the request field section");
+  Expect(result.executed_action_count == 1,
+         "HTTP/3 server did not execute exactly one structured action");
+  Expect(result.server_port != 0,
+         "HTTP/3 server did not expose its kernel-selected UDP port");
+}
+
+void TestRawResponseStreamDataFrame() {
+  Scenario scenario;
+  auto *headers_action = scenario.mutable_http3_plan()->add_actions();
+  auto *response = headers_action->mutable_structured_response();
+  response->set_status_code(200);
+  response->set_finish_stream(false);
+
+  // HTTP/3 DATA frame: type=0, length=3, payload="raw". The peer writes
+  // these bytes directly to the response QUIC stream after nghttp3 has made
+  // the preceding HEADERS block, so curl parses mutator-controlled plaintext.
+  auto *raw_action = scenario.mutable_http3_plan()->add_actions();
+  auto *write = raw_action->mutable_stream_write();
+  write->set_role(curl::fuzzer::proto::HTTP3_STREAM_RESPONSE);
+  write->set_data(std::string("\x00\x03raw", 5));
+  write->set_finish_stream(true);
+
+  const Http3RunResult result = RunScenario(scenario, "raw-data-frame");
+  Expect(result.code == CURLE_OK,
+         "raw response-stream HTTP/3 transfer did not complete");
+  Expect(result.http_version == CURL_HTTP_VERSION_3,
+         "raw response-stream transfer did not use HTTP/3");
+  Expect(result.body == "raw",
+         "curl did not parse the directly-written HTTP/3 DATA frame");
+  Expect(result.handshake_complete && result.request_headers_received,
+         "raw response-stream case did not reach HTTP/3 application data");
+  Expect(result.executed_action_count == 2,
+         "HTTP/3 server did not execute both structured and raw actions");
+  Expect(result.server_port != 0,
+         "raw HTTP/3 case did not bind a private UDP port");
+}
+
+void TestRawResponseFromFrameZero() {
+  Scenario scenario;
+  auto *action = scenario.mutable_http3_plan()->add_actions();
+  auto *write = action->mutable_stream_write();
+  write->set_role(curl::fuzzer::proto::HTTP3_STREAM_RESPONSE);
+
+  // HEADERS(type=1, length=3), followed by a QPACK field section with zero
+  // dynamic-table state and the static :status=200 entry. DATA then carries
+  // "raw-first". No byte on the response stream is generated by nghttp3.
+  write->set_data(std::string("\x01\x03\x00\x00\xd9\x00\x09raw-first", 16));
+  write->set_finish_stream(true);
+
+  const Http3RunResult result = RunScenario(scenario, "raw-from-frame-zero");
+  Expect(result.code == CURLE_OK, "raw-first HTTP/3 response did not complete");
+  Expect(result.response_code == 200,
+         "curl did not decode the raw-first QPACK status field");
+  Expect(result.http_version == CURL_HTTP_VERSION_3,
+         "raw-first response did not use HTTP/3");
+  Expect(result.body == "raw-first",
+         "curl did not parse response bytes written from frame zero");
+  Expect(result.executed_action_count == 1,
+         "HTTP/3 server did not execute the raw-first response action");
+}
+
+void TestFreshUnknownUnidirectionalStream() {
+  Scenario scenario;
+  auto *raw_action = scenario.mutable_http3_plan()->add_actions();
+  auto *stream = raw_action->mutable_open_unidirectional_stream();
+  // 0x21 is an unknown HTTP/3 unidirectional stream type. Because this action
+  // owns a new QUIC stream, it is also the literal first byte curl receives.
+  stream->set_data(std::string("\x21unknown-stream", 15));
+  stream->set_finish_stream(true);
+
+  auto *response_action = scenario.mutable_http3_plan()->add_actions();
+  auto *response = response_action->mutable_structured_response();
+  response->set_status_code(200);
+  response->add_body_chunks("after unknown stream");
+  response->set_finish_stream(true);
+
+  const Http3RunResult result = RunScenario(scenario, "unknown-uni-stream");
+  Expect(result.code == CURLE_OK,
+         "an unknown unidirectional stream prevented response completion");
+  Expect(result.http_version == CURL_HTTP_VERSION_3,
+         "unknown-stream transfer did not use HTTP/3");
+  Expect(result.body == "after unknown stream",
+         "curl did not ignore the fresh unknown unidirectional stream");
+  Expect(result.executed_action_count == 2,
+         "HTTP/3 server did not execute the fresh-stream and response actions");
+}
+
+} // namespace
+
+int main() {
+  if (curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
+    Fail("curl_global_init failed");
+  }
+  TestStructuredResponseWithTrailers();
+  TestRawResponseStreamDataFrame();
+  TestRawResponseFromFrameZero();
+  TestFreshUnknownUnidirectionalStream();
+  curl_global_cleanup();
+  return 0;
+}

--- a/tests/target_policy_test.cc
+++ b/tests/target_policy_test.cc
@@ -175,16 +175,216 @@ void TestFastHttpsPolicy() {
          "fast HTTPS policy discarded its certificate-chain selector");
 }
 
-void TestFastHttpsPolicyRejectsUnknownCertificateChain() {
-  Scenario scenario;
+void TestTlsPoliciesRejectUnknownCertificateChain() {
+  constexpr TargetProfile kTlsPolicies[] = {
+      TargetProfile::kFastHttps,
+      TargetProfile::kFastHttp3,
+  };
+  for (const TargetProfile profile : kTlsPolicies) {
+    Scenario scenario;
+    scenario.set_tls_certificate_chain(
+        static_cast<curl::fuzzer::proto::TlsCertificateChainProfile>(99));
+
+    ApplyTargetPolicy(&scenario, profile);
+
+    Expect(scenario.tls_certificate_chain() ==
+               curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC,
+           "a TLS policy retained an unknown certificate-chain selector");
+  }
+}
+
+void TestFastHttp3PolicyMaterializesUsefulPlan() {
+  Scenario scenario = ScenarioWithBackpressure(SCHEME_HTTP, 4096, 17);
+  scenario.set_host_path("mutated.example:8443/a/path?query#fragment");
+  scenario.add_request_headers("X-H3: retained");
+  scenario.add_subsequent_connections()->set_initial_response(
+      "ignored stream response");
+  scenario.mutable_mime_post()->add_parts()->set_data("mime sentinel");
+  scenario.mutable_upload()->set_data("upload sentinel");
+  scenario.add_telnet_options("TTYPE=ignored");
+  scenario.mutable_api_plan()->set_duplicate_easy(true);
+  scenario.mutable_multi_plan()->set_transfer_count(4);
   scenario.set_tls_certificate_chain(
-      static_cast<curl::fuzzer::proto::TlsCertificateChainProfile>(99));
+      curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES);
+  scenario.mutable_http3_plan();
 
-  ApplyTargetPolicy(&scenario, TargetProfile::kFastHttps);
+  scenario.add_options()->set_option_id(
+      curl::fuzzer::proto::CURLOPT_HTTP_VERSION);
+  scenario.add_options()->set_option_id(
+      curl::fuzzer::proto::CURLOPT_CONNECT_ONLY);
+  scenario.add_options()->set_option_id(curl::fuzzer::proto::CURLOPT_POST);
 
+  ApplyTargetPolicy(&scenario, TargetProfile::kFastHttp3);
+
+  Expect(scenario.scheme() == SCHEME_HTTPS,
+         "fast HTTP/3 policy did not force HTTPS");
+  Expect(scenario.host_path() == "tls.test/a/path?query#fragment",
+         "fast HTTP/3 policy did not retain the URL suffix");
+  Expect(!scenario.has_connection() &&
+             scenario.subsequent_connections_size() == 0,
+         "fast HTTP/3 policy retained stream-socket response scripts");
+  Expect(scenario.request_headers_size() == 1 && scenario.has_mime_post() &&
+             scenario.has_upload(),
+         "fast HTTP/3 policy removed request-side HTTP state");
+  Expect(scenario.telnet_options_size() == 0 && !scenario.has_api_plan() &&
+             !scenario.has_multi_plan(),
+         "fast HTTP/3 policy retained another target's work");
   Expect(scenario.tls_certificate_chain() ==
-             curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_DEFAULT_EC,
-         "fast HTTPS policy retained an unknown certificate-chain selector");
+             curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES,
+         "fast HTTP/3 policy discarded its certificate-chain selector");
+  Expect(scenario.options_size() == 1 && scenario.options(0).option_id() ==
+                                             curl::fuzzer::proto::CURLOPT_POST,
+         "fast HTTP/3 policy retained transport-breaking options");
+  Expect(scenario.has_http3_plan() && scenario.http3_plan().actions_size() == 1,
+         "fast HTTP/3 policy did not materialize a default peer action");
+  const auto &response = scenario.http3_plan().actions(0).structured_response();
+  Expect(response.status_code() == 200 && response.finish_stream(),
+         "fast HTTP/3 default action is not a finished 200 response");
+}
+
+void TestFastHttp3PolicyBoundsOrderedActions() {
+  Scenario scenario;
+  auto *plan = scenario.mutable_http3_plan();
+
+  auto *response = plan->add_actions()->mutable_structured_response();
+  response->set_status_code(700);
+  auto *first_header = response->add_response_headers();
+  first_header->set_name(":Bad NAME");
+  first_header->set_value(std::string("ok\r\n\0bad\x7f", 9));
+  for (std::size_t index = 0;
+       index < proto_fuzzer::scenario_limits::kMaxHttp3Headers + 4; ++index) {
+    auto *header = response->add_response_headers();
+    header->set_name(std::string(
+        proto_fuzzer::scenario_limits::kMaxHttp3HeaderNameBytes + 8, 'N'));
+    header->set_value(std::string(
+        proto_fuzzer::scenario_limits::kMaxHttp3HeaderValueBytes + 8, 'v'));
+  }
+  for (std::size_t index = 0;
+       index < proto_fuzzer::scenario_limits::kMaxHttp3Trailers + 4; ++index) {
+    auto *trailer = response->add_response_trailers();
+    trailer->set_name("X-Trailer");
+    trailer->set_value("value");
+  }
+  for (std::size_t index = 0;
+       index < proto_fuzzer::scenario_limits::kMaxHttp3BodyChunks + 4;
+       ++index) {
+    response->add_body_chunks(std::string(
+        proto_fuzzer::scenario_limits::kMaxHttp3BodyBytes + 8, 'b'));
+  }
+
+  auto *write = plan->add_actions()->mutable_stream_write();
+  write->set_role(static_cast<curl::fuzzer::proto::Http3StreamRole>(99));
+  write->set_data(std::string(
+      proto_fuzzer::scenario_limits::kMaxHttp3RawWriteBytes + 8, 'r'));
+  write->set_finish_stream(true);
+
+  auto *opened_stream =
+      plan->add_actions()->mutable_open_unidirectional_stream();
+  opened_stream->set_data(std::string(
+      proto_fuzzer::scenario_limits::kMaxHttp3RawWriteBytes + 8, 'u'));
+  opened_stream->set_finish_stream(true);
+
+  auto *reset = plan->add_actions()->mutable_stream_reset();
+  reset->set_role(static_cast<curl::fuzzer::proto::Http3StreamRole>(99));
+  reset->set_application_error_code(std::numeric_limits<std::uint64_t>::max());
+  plan->add_actions()->mutable_goaway()->set_id(
+      std::numeric_limits<std::uint64_t>::max());
+  plan->add_actions();
+  while (static_cast<std::size_t>(plan->actions_size()) <
+         proto_fuzzer::scenario_limits::kMaxHttp3Actions - 1) {
+    plan->add_actions()->mutable_stream_write()->set_data("suffix");
+  }
+  plan->add_actions()->mutable_connection_close()->set_application_error_code(
+      std::numeric_limits<std::uint64_t>::max());
+  for (int index = 0; index < 4; ++index) {
+    plan->add_actions()->mutable_stream_write()->set_data("ignored suffix");
+  }
+
+  ApplyTargetPolicy(&scenario, TargetProfile::kFastHttp3);
+
+  Expect(static_cast<std::size_t>(scenario.http3_plan().actions_size()) ==
+             proto_fuzzer::scenario_limits::kMaxHttp3Actions,
+         "fast HTTP/3 policy retained actions beyond its operation budget");
+  const auto &bounded_response =
+      scenario.http3_plan().actions(0).structured_response();
+  Expect(bounded_response.status_code() == 300,
+         "fast HTTP/3 policy did not fold status into 100..599");
+  Expect(bounded_response.response_headers(0).name() == "-bad-name",
+         "fast HTTP/3 policy did not canonicalize a field name");
+  Expect(bounded_response.response_headers(0).value() ==
+             std::string("ok   bad ", 9),
+         "fast HTTP/3 policy retained controls in a field value");
+  Expect(
+      static_cast<std::size_t>(bounded_response.response_headers_size()) <=
+              proto_fuzzer::scenario_limits::kMaxHttp3Headers &&
+          static_cast<std::size_t>(bounded_response.response_trailers_size()) <=
+              proto_fuzzer::scenario_limits::kMaxHttp3Trailers,
+      "fast HTTP/3 policy retained too many fields");
+
+  std::size_t body_bytes = 0;
+  for (const std::string &chunk : bounded_response.body_chunks()) {
+    body_bytes += chunk.size();
+  }
+  Expect(static_cast<std::size_t>(bounded_response.body_chunks_size()) ==
+                 proto_fuzzer::scenario_limits::kMaxHttp3BodyChunks &&
+             body_bytes == proto_fuzzer::scenario_limits::kMaxHttp3BodyBytes,
+         "fast HTTP/3 policy did not apply its body budgets");
+
+  const auto &bounded_write = scenario.http3_plan().actions(1).stream_write();
+  Expect(bounded_write.role() == curl::fuzzer::proto::HTTP3_STREAM_RESPONSE &&
+             bounded_write.data().size() ==
+                 proto_fuzzer::scenario_limits::kMaxHttp3RawWriteBytes &&
+             bounded_write.finish_stream(),
+         "fast HTTP/3 policy did not bound a raw write in place");
+  const auto &bounded_open =
+      scenario.http3_plan().actions(2).open_unidirectional_stream();
+  Expect(bounded_open.data().size() ==
+                 proto_fuzzer::scenario_limits::kMaxHttp3RawWriteBytes &&
+             bounded_open.finish_stream(),
+         "fast HTTP/3 policy did not bound a fresh raw stream in place");
+       const std::uint64_t max_quic_varint =
+                     proto_fuzzer::scenario_limits::kMaxQuicVarint;
+  const auto &bounded_reset = scenario.http3_plan().actions(3).stream_reset();
+  Expect(bounded_reset.role() == curl::fuzzer::proto::HTTP3_STREAM_RESPONSE &&
+             bounded_reset.application_error_code() == max_quic_varint,
+         "fast HTTP/3 policy did not canonicalize a stream reset");
+  Expect(scenario.http3_plan().actions(4).goaway().id() ==
+             (max_quic_varint & ~std::uint64_t{3}),
+         "fast HTTP/3 policy did not canonicalize a GOAWAY stream ID");
+  Expect(scenario.http3_plan()
+                 .actions(static_cast<int>(
+                     proto_fuzzer::scenario_limits::kMaxHttp3Actions - 1))
+                 .connection_close()
+                 .application_error_code() == max_quic_varint,
+         "fast HTTP/3 policy did not bound a connection-close error");
+  const auto &defaulted =
+      scenario.http3_plan().actions(5).structured_response();
+  Expect(defaulted.status_code() == 200 && defaulted.finish_stream(),
+         "fast HTTP/3 policy left an empty ordered action inert");
+}
+
+void TestNonHttp3PoliciesDiscardPlans() {
+  constexpr TargetProfile kOtherPolicies[] = {
+      TargetProfile::kFastHttp,      TargetProfile::kDeepHttp,
+      TargetProfile::kFastHttps,     TargetProfile::kH2Proxy,
+      TargetProfile::kFastWebSocket, TargetProfile::kFastSecureWebSocket,
+      TargetProfile::kFastTelnet,    TargetProfile::kFastFtp,
+      TargetProfile::kFastTftp,      TargetProfile::kApi,
+      TargetProfile::kMulti,         TargetProfile::kTiming,
+  };
+
+  for (const TargetProfile profile : kOtherPolicies) {
+    Scenario scenario;
+    scenario.mutable_http3_plan()
+        ->add_actions()
+        ->mutable_structured_response()
+        ->set_status_code(204);
+
+    ApplyTargetPolicy(&scenario, profile);
+
+    Expect(!scenario.has_http3_plan(),
+           "a non-HTTP/3 policy retained QUIC-peer work");
+  }
 }
 
 void TestNonHttpsPoliciesDiscardTlsCertificateChains() {
@@ -835,11 +1035,17 @@ void TestApiPolicyRetainsAndBoundsItsPlan() {
 
 void TestProtocolPoliciesDiscardApiPlans() {
   constexpr TargetProfile kProtocolPolicies[] = {
-      TargetProfile::kFastHttp,      TargetProfile::kDeepHttp,
-      TargetProfile::kFastHttps,     TargetProfile::kH2Proxy,
-      TargetProfile::kFastWebSocket, TargetProfile::kFastSecureWebSocket,
-      TargetProfile::kFastTelnet,    TargetProfile::kFastFtp,
-      TargetProfile::kFastTftp,      TargetProfile::kMulti,
+      TargetProfile::kFastHttp,
+      TargetProfile::kDeepHttp,
+      TargetProfile::kFastHttps,
+      TargetProfile::kFastHttp3,
+      TargetProfile::kH2Proxy,
+      TargetProfile::kFastWebSocket,
+      TargetProfile::kFastSecureWebSocket,
+      TargetProfile::kFastTelnet,
+      TargetProfile::kFastFtp,
+      TargetProfile::kFastTftp,
+      TargetProfile::kMulti,
       TargetProfile::kTiming,
   };
 
@@ -916,11 +1122,17 @@ void TestMultiPolicyRetainsAndBoundsItsPlan() {
 
 void TestOtherPoliciesDiscardMultiPlans() {
   constexpr TargetProfile kOtherPolicies[] = {
-      TargetProfile::kFastHttp,      TargetProfile::kDeepHttp,
-      TargetProfile::kFastHttps,     TargetProfile::kH2Proxy,
-      TargetProfile::kFastWebSocket, TargetProfile::kFastSecureWebSocket,
-      TargetProfile::kFastTelnet,    TargetProfile::kFastFtp,
-      TargetProfile::kFastTftp,      TargetProfile::kApi,
+      TargetProfile::kFastHttp,
+      TargetProfile::kDeepHttp,
+      TargetProfile::kFastHttps,
+      TargetProfile::kFastHttp3,
+      TargetProfile::kH2Proxy,
+      TargetProfile::kFastWebSocket,
+      TargetProfile::kFastSecureWebSocket,
+      TargetProfile::kFastTelnet,
+      TargetProfile::kFastFtp,
+      TargetProfile::kFastTftp,
+      TargetProfile::kApi,
       TargetProfile::kTiming,
   };
   for (const TargetProfile profile : kOtherPolicies) {
@@ -963,6 +1175,9 @@ void TestProfileRunModes() {
          "multi profile does not authorize concurrent transfers");
   Expect(RunModeFor(TargetProfile::kFastHttps) == ScenarioRunMode::kTlsCoverage,
          "fast HTTPS profile does not authorize the real TLS peer");
+  Expect(RunModeFor(TargetProfile::kFastHttp3) ==
+             ScenarioRunMode::kHttp3Coverage,
+         "fast HTTP/3 profile does not authorize the QUIC peer");
   Expect(RunModeFor(TargetProfile::kH2Proxy) ==
              ScenarioRunMode::kH2ProxyCoverage,
          "HTTP/2 proxy profile does not authorize its CONNECT peer");
@@ -990,6 +1205,10 @@ void TestCompatibilityProfileIsNoOp() {
   scenario.mutable_multi_plan()->set_transfer_count(4);
   scenario.set_tls_certificate_chain(
       curl::fuzzer::proto::TLS_CERTIFICATE_CHAIN_ALL_KEY_TYPES);
+  scenario.mutable_http3_plan()
+      ->add_actions()
+      ->mutable_stream_write()
+      ->set_data("compatibility H3 bytes");
   scenario.add_request_headers("X-Compatibility: retained");
   const std::string before = scenario.SerializeAsString();
 
@@ -1005,7 +1224,10 @@ int main() {
   TestFastHttpPolicy();
   TestDeepHttpPolicy();
   TestFastHttpsPolicy();
-  TestFastHttpsPolicyRejectsUnknownCertificateChain();
+  TestTlsPoliciesRejectUnknownCertificateChain();
+  TestFastHttp3PolicyMaterializesUsefulPlan();
+  TestFastHttp3PolicyBoundsOrderedActions();
+  TestNonHttp3PoliciesDiscardPlans();
   TestNonHttpsPoliciesDiscardTlsCertificateChains();
   TestH2ProxyPolicy();
   TestFastWebSocketPolicy();

--- a/tests/test_compare_fuzzers.py
+++ b/tests/test_compare_fuzzers.py
@@ -366,6 +366,48 @@ def test_mbedtls_https_lane_reuses_compatible_https_corpora(
     ]
 
 
+def test_http3_lane_reuses_compatible_https_corpora(tmp_path: Path) -> None:
+    module = _load_module()
+    corpus_root = tmp_path / "corpora"
+    http3_corpus = corpus_root / "curl_fuzzer_proto_http3"
+    https_corpus = corpus_root / "curl_fuzzer_proto_https"
+    http3_corpus.mkdir(parents=True)
+    https_corpus.mkdir()
+    (http3_corpus / "h3-seed").write_bytes(b"http3")
+    (https_corpus / "https-seed").write_bytes(b"https")
+
+    baseline_dir = tmp_path / "bin"
+    baseline_dir.mkdir()
+    https_seed_archive = baseline_dir / "curl_fuzzer_proto_https_seed_corpus.zip"
+    https_seed_archive.write_bytes(b"seed archive")
+
+    public_root = tmp_path / "public"
+    http3_public = public_root / "curl_fuzzer_proto_http3"
+    https_public = public_root / "curl_fuzzer_proto_https"
+    historical_public = public_root / "curl_fuzzer_proto"
+    for directory in (http3_public, https_public, historical_public):
+        directory.mkdir(parents=True)
+        (directory / "input").write_bytes(directory.name.encode())
+
+    sources = module._corpus_sources(
+        "curl_fuzzer_proto_http3",
+        baseline_dir,
+        corpus_root,
+        public_root,
+        {},
+    )
+
+    assert "curl_fuzzer_proto_http3" in module.DEFAULT_TARGETS
+    assert sources == [
+        http3_corpus,
+        https_corpus,
+        https_seed_archive,
+        http3_public,
+        https_public,
+        historical_public,
+    ]
+
+
 def test_ftp_and_tftp_lanes_keep_legacy_speed_baselines() -> None:
     module = _load_module()
 

--- a/tests/test_fuzzer_entrypoints.py
+++ b/tests/test_fuzzer_entrypoints.py
@@ -29,6 +29,7 @@ PROTO_TARGET_PROFILES = {
     "curl_fuzzer_proto_https": "kFastHttps",
     "curl_fuzzer_proto_https_gnutls": "kFastHttps",
     "curl_fuzzer_proto_https_mbedtls": "kFastHttps",
+    "curl_fuzzer_proto_http3": "kFastHttp3",
     "curl_fuzzer_proto_h2_proxy": "kH2Proxy",
     "curl_fuzzer_proto_ws": "kFastWebSocket",
     "curl_fuzzer_proto_wss": "kFastSecureWebSocket",
@@ -63,11 +64,12 @@ def _packaged_targets(
     return set(result.stdout.splitlines())
 
 
-def test_alternative_tls_targets_are_limited_to_supported_builds() -> None:
+def test_optional_proto_targets_are_limited_to_supported_builds() -> None:
     """Keep packaging aligned with the CMake sanitizer/architecture gates."""
     targets = {
         "curl_fuzzer_proto_https_gnutls",
         "curl_fuzzer_proto_https_mbedtls",
+        "curl_fuzzer_proto_http3",
     }
 
     assert targets <= _packaged_targets()


### PR DESCRIPTION
Build an HTTP/3 curl variant using ngtcp2 and nghttp3 while reusing the existing OpenSSL dependency. Add structured and raw HTTP/3 actions, corpus seeds, packaging support, and integration tests.