### PR TITLE
build: invalidate GnuTLS caches on dependency updates

### DIFF
--- a/cmake/GnuTLSDependencies.cmake
+++ b/cmake/GnuTLSDependencies.cmake
@@ -43,8 +43,9 @@ endif()
 
 # renovate: datasource=custom.gnu depName=gmp
 set(GNUTLS_GMP_VERSION 6.3.0)
+set(GNUTLS_GMP_CACHE_ID gmp-${GNUTLS_GMP_VERSION})
 set(GNUTLS_GMP_INSTALL_DIR
-    ${CMAKE_BINARY_DIR}/gmp-${GNUTLS_GMP_VERSION}-install)
+    ${CMAKE_BINARY_DIR}/${GNUTLS_GMP_CACHE_ID}-install)
 set(GNUTLS_GMP_INCLUDE_DIR ${GNUTLS_GMP_INSTALL_DIR}/include)
 set(GNUTLS_GMP_STATIC_LIB ${GNUTLS_GMP_INSTALL_DIR}/lib/libgmp.a)
 set(GNUTLS_GMP_INSTALL_STAMP
@@ -57,7 +58,7 @@ if(NOT EXISTS ${GNUTLS_GMP_INSTALL_STAMP} OR
             https://ftp.gnu.org/gnu/gmp/gmp-${GNUTLS_GMP_VERSION}.tar.xz
             https://ftpmirror.gnu.org/gmp/gmp-${GNUTLS_GMP_VERSION}.tar.xz
         PREFIX
-            ${CMAKE_BINARY_DIR}/gmp-${GNUTLS_GMP_VERSION}-${MINIMAL_INSTALL_RECIPE}
+            ${CMAKE_BINARY_DIR}/${GNUTLS_GMP_CACHE_ID}-${MINIMAL_INSTALL_RECIPE}
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env
                 "CC=${_GNUTLS_DEPS_CC}"
@@ -91,8 +92,12 @@ endif()
 
 # renovate: datasource=custom.gnu depName=nettle
 set(GNUTLS_NETTLE_VERSION 4.0)
+# Cache identities include the complete static dependency closure. A Nettle
+# archive built against one GMP release must not be reused with another.
+set(GNUTLS_NETTLE_CACHE_ID
+    nettle-${GNUTLS_NETTLE_VERSION}-${GNUTLS_GMP_CACHE_ID})
 set(GNUTLS_NETTLE_INSTALL_DIR
-    ${CMAKE_BINARY_DIR}/nettle-${GNUTLS_NETTLE_VERSION}-install)
+    ${CMAKE_BINARY_DIR}/${GNUTLS_NETTLE_CACHE_ID}-install)
 set(GNUTLS_NETTLE_INCLUDE_DIR ${GNUTLS_NETTLE_INSTALL_DIR}/include)
 set(GNUTLS_NETTLE_STATIC_LIB
     ${GNUTLS_NETTLE_INSTALL_DIR}/lib/libnettle.a)
@@ -121,7 +126,7 @@ if(NOT EXISTS ${GNUTLS_NETTLE_INSTALL_STAMP} OR
             https://ftp.gnu.org/gnu/nettle/nettle-${GNUTLS_NETTLE_VERSION}.tar.gz
             https://ftpmirror.gnu.org/nettle/nettle-${GNUTLS_NETTLE_VERSION}.tar.gz
         PREFIX
-            ${CMAKE_BINARY_DIR}/nettle-${GNUTLS_NETTLE_VERSION}-${MINIMAL_INSTALL_RECIPE}
+            ${CMAKE_BINARY_DIR}/${GNUTLS_NETTLE_CACHE_ID}-${MINIMAL_INSTALL_RECIPE}
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env
                 "CC=${_GNUTLS_DEPS_CC}"
@@ -167,7 +172,11 @@ endif()
 # renovate: datasource=gitlab-tags depName=gnutls/gnutls
 set(GNUTLS_VERSION 3.8.13)
 string(REGEX MATCH "^[0-9]+\\.[0-9]+" GNUTLS_SERIES "${GNUTLS_VERSION}")
-set(GNUTLS_INSTALL_DIR ${CMAKE_BINARY_DIR}/gnutls-${GNUTLS_VERSION}-install)
+# GnuTLS compiles against Nettle's headers, so a Nettle or GMP upgrade must
+# invalidate the cached GnuTLS archive even when GNUTLS_VERSION is unchanged.
+set(GNUTLS_CACHE_ID
+    gnutls-${GNUTLS_VERSION}-${GNUTLS_NETTLE_CACHE_ID})
+set(GNUTLS_INSTALL_DIR ${CMAKE_BINARY_DIR}/${GNUTLS_CACHE_ID}-install)
 set(GNUTLS_INCLUDE_DIR ${GNUTLS_INSTALL_DIR}/include)
 set(GNUTLS_STATIC_LIB ${GNUTLS_INSTALL_DIR}/lib/libgnutls.a)
 set(GNUTLS_INSTALL_STAMP
@@ -191,7 +200,7 @@ if(NOT EXISTS ${GNUTLS_INSTALL_STAMP} OR
         URL
             https://www.gnupg.org/ftp/gcrypt/gnutls/v${GNUTLS_SERIES}/gnutls-${GNUTLS_VERSION}.tar.xz
         PREFIX
-            ${CMAKE_BINARY_DIR}/gnutls-${GNUTLS_VERSION}-${MINIMAL_INSTALL_RECIPE}
+            ${CMAKE_BINARY_DIR}/${GNUTLS_CACHE_ID}-${MINIMAL_INSTALL_RECIPE}
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env
                 "CC=${_GNUTLS_DEPS_CC}"

--- a/tests/test_gnutls_dependency_cache.py
+++ b/tests/test_gnutls_dependency_cache.py
@@ -1,0 +1,106 @@
+"""Regression tests for GnuTLS dependency cache invalidation."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GNUTLS_DEPENDENCIES = REPO_ROOT / "cmake" / "GnuTLSDependencies.cmake"
+
+
+def _replace_version(module: str, variable: str, version: str) -> str:
+    module, replacements = re.subn(
+        rf"set\({re.escape(variable)} [^)]+\)",
+        f"set({variable} {version})",
+        module,
+        count=1,
+    )
+    assert replacements == 1
+    return module
+
+
+def _cache_names(
+    tmp_path: Path, *, gmp_version: str | None = None, nettle_version: str | None = None
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    source_dir = tmp_path / "source"
+    build_dir = tmp_path / "build"
+    source_dir.mkdir(parents=True)
+
+    module = GNUTLS_DEPENDENCIES.read_text(encoding="utf-8")
+    if gmp_version is not None:
+        module = _replace_version(module, "GNUTLS_GMP_VERSION", gmp_version)
+    if nettle_version is not None:
+        module = _replace_version(module, "GNUTLS_NETTLE_VERSION", nettle_version)
+    (source_dir / "GnuTLSDependencies.cmake").write_text(module, encoding="utf-8")
+
+    (source_dir / "CMakeLists.txt").write_text(
+        """\
+cmake_minimum_required(VERSION 3.24)
+project(gnutls_cache_identity NONE)
+include(${CMAKE_CURRENT_SOURCE_DIR}/GnuTLSDependencies.cmake)
+
+file(WRITE ${CMAKE_BINARY_DIR}/cache-installs.txt "")
+foreach(install_dir IN LISTS GNUTLS_CACHE_INSTALL_DIRS)
+    get_filename_component(install_name ${install_dir} NAME)
+    file(APPEND ${CMAKE_BINARY_DIR}/cache-installs.txt "${install_name}\\n")
+endforeach()
+
+file(WRITE ${CMAKE_BINARY_DIR}/cache-prefixes.txt "")
+foreach(target IN ITEMS
+        gnutls_gmp_external
+        gnutls_nettle_external
+        gnutls_external)
+    get_property(prefix TARGET ${target} PROPERTY _EP_PREFIX)
+    get_filename_component(prefix_name ${prefix} NAME)
+    file(APPEND ${CMAKE_BINARY_DIR}/cache-prefixes.txt "${prefix_name}\\n")
+endforeach()
+""",
+        encoding="utf-8",
+    )
+
+    subprocess.run(
+        ["cmake", "-S", str(source_dir), "-B", str(build_dir)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return (
+        tuple(
+            (build_dir / "cache-installs.txt").read_text(encoding="utf-8").splitlines()
+        ),
+        tuple(
+            (build_dir / "cache-prefixes.txt").read_text(encoding="utf-8").splitlines()
+        ),
+    )
+
+
+def test_transitive_versions_are_part_of_gnutls_cache_identities(
+    tmp_path: Path,
+) -> None:
+    """A restored upper-layer prefix must not survive a dependency bump."""
+    baseline = _cache_names(tmp_path / "baseline")
+    bumped_gmp = _cache_names(tmp_path / "bumped-gmp", gmp_version="99.1-cache-test")
+    bumped_nettle = _cache_names(
+        tmp_path / "bumped-nettle", nettle_version="99.2-cache-test"
+    )
+
+    for baseline_names, bumped_gmp_names, bumped_nettle_names in zip(
+        baseline, bumped_gmp, bumped_nettle, strict=True
+    ):
+        assert (
+            len(baseline_names)
+            == len(bumped_gmp_names)
+            == len(bumped_nettle_names)
+            == 3
+        )
+        gmp, nettle, gnutls = range(3)
+
+        assert bumped_gmp_names[gmp] != baseline_names[gmp]
+        assert bumped_gmp_names[nettle] != baseline_names[nettle]
+        assert bumped_gmp_names[gnutls] != baseline_names[gnutls]
+
+        assert bumped_nettle_names[gmp] == baseline_names[gmp]
+        assert bumped_nettle_names[nettle] != baseline_names[nettle]
+        assert bumped_nettle_names[gnutls] != baseline_names[gnutls]


### PR DESCRIPTION
This pull request improves the caching strategy for GnuTLS and its dependencies in the CMake build configuration, ensuring that cache directories are properly invalidated when underlying dependency versions change. It also adds a regression test to verify the correctness of cache invalidation when dependency versions are updated.

**Build system improvements:**

* Refactored cache directory naming for GMP, Nettle, and GnuTLS to include the specific versions of their dependencies, ensuring that any change in a lower-level dependency (e.g., GMP or Nettle) results in a new cache identity and prevents reuse of outdated build artifacts. [[1]](diffhunk://#diff-f86912ffcd250f4b9dfcf130d8170cdd1a1777f651ac62a957b83a52348326e4R46-R48) [[2]](diffhunk://#diff-f86912ffcd250f4b9dfcf130d8170cdd1a1777f651ac62a957b83a52348326e4L60-R61) [[3]](diffhunk://#diff-f86912ffcd250f4b9dfcf130d8170cdd1a1777f651ac62a957b83a52348326e4R95-R100) [[4]](diffhunk://#diff-f86912ffcd250f4b9dfcf130d8170cdd1a1777f651ac62a957b83a52348326e4L124-R129) [[5]](diffhunk://#diff-f86912ffcd250f4b9dfcf130d8170cdd1a1777f651ac62a957b83a52348326e4L170-R179) [[6]](diffhunk://#diff-f86912ffcd250f4b9dfcf130d8170cdd1a1777f651ac62a957b83a52348326e4L194-R203)

**Testing enhancements:**

* Added a new test (`tests/test_gnutls_dependency_cache.py`) that programmatically bumps GMP and Nettle versions and verifies that cache directories and build prefixes are correctly updated, preventing accidental reuse of incompatible cached builds.