### PR TITLE
Add coverage for various things

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,7 @@ set(CURL_COMMON_CMAKE_ARGS
     -DCURL_DISABLE_TELNET=OFF
     -DCURL_DISABLE_FTP=OFF
     -DCURL_DISABLE_TFTP=OFF
+    -DCURL_DISABLE_GOPHER=OFF
     # SMB and NTLM are deprecated upstream and no longer fuzzed here. Keep
     # them disabled explicitly so curl default changes cannot restore either
     # surface to the aggregate legacy fuzzer.
@@ -1482,6 +1483,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
     curl_add_proto_fuzzer(curl_fuzzer_proto_telnet)
     curl_add_proto_fuzzer(curl_fuzzer_proto_ftp)
     curl_add_proto_fuzzer(curl_fuzzer_proto_tftp)
+    curl_add_proto_fuzzer(curl_fuzzer_proto_gopher)
     curl_add_proto_fuzzer(curl_fuzzer_proto_api)
     curl_add_proto_fuzzer(curl_fuzzer_proto_multi)
     curl_add_proto_fuzzer(curl_fuzzer_proto_timing)
@@ -1508,6 +1510,8 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
          ${SCENARIO_SRC_DIR}/ftp/*.textproto)
     file(GLOB TFTP_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
          ${SCENARIO_SRC_DIR}/tftp/*.textproto)
+    file(GLOB GOPHER_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
+         ${SCENARIO_SRC_DIR}/gopher/*.textproto)
     file(GLOB API_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
          ${SCENARIO_SRC_DIR}/api/*.textproto)
     file(GLOB MULTI_SCENARIO_TEXTPROTOS CONFIGURE_DEPENDS
@@ -1660,6 +1664,8 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         curl_fuzzer_proto_ftp ${FTP_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_tftp_corpus
         curl_fuzzer_proto_tftp ${TFTP_SCENARIO_TEXTPROTOS})
+    add_proto_fuzzer_corpus(curl_fuzzer_proto_gopher_corpus
+        curl_fuzzer_proto_gopher ${GOPHER_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_api_corpus
         curl_fuzzer_proto_api ${API_SCENARIO_TEXTPROTOS})
     add_proto_fuzzer_corpus(curl_fuzzer_proto_multi_corpus
@@ -1691,6 +1697,7 @@ if(NOT "$ENV{ARCHITECTURE}" STREQUAL "i386")
         curl_fuzzer_proto_telnet_corpus)
     add_dependencies(curl_fuzzer_proto_ftp curl_fuzzer_proto_ftp_corpus)
     add_dependencies(curl_fuzzer_proto_tftp curl_fuzzer_proto_tftp_corpus)
+    add_dependencies(curl_fuzzer_proto_gopher curl_fuzzer_proto_gopher_corpus)
     add_dependencies(curl_fuzzer_proto_api curl_fuzzer_proto_api_corpus)
     add_dependencies(curl_fuzzer_proto_multi curl_fuzzer_proto_multi_corpus)
     add_dependencies(curl_fuzzer_proto_timing curl_fuzzer_proto_timing_corpus)

--- a/fuzzer_entrypoints/curl_fuzzer_proto_gopher.cc
+++ b/fuzzer_entrypoints/curl_fuzzer_proto_gopher.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) Max Dymond, <cmeister2@gmail.com>, et al.
+ *
+ * SPDX-License-Identifier: curl
+ */
+
+#include "proto_fuzzer/fuzzer_main.h"
+
+namespace {
+
+// Keep mutation, crossover, and execution on the Gopher policy.
+constexpr auto kProfile = proto_fuzzer::TargetProfile::kFastGopher;
+
+} // namespace
+
+extern "C" std::size_t LLVMFuzzerCustomMutator(std::uint8_t *data,
+                                               std::size_t size,
+                                               std::size_t max_size,
+                                               unsigned int seed) {
+  return proto_fuzzer::ProtoFuzzerCustomMutator(kProfile, data, size, max_size,
+                                                seed);
+}
+
+extern "C" std::size_t
+LLVMFuzzerCustomCrossOver(const std::uint8_t *data1, std::size_t size1,
+                          const std::uint8_t *data2, std::size_t size2,
+                          std::uint8_t *out, std::size_t max_out_size,
+                          unsigned int seed) {
+  return proto_fuzzer::ProtoFuzzerCustomCrossOver(
+      kProfile, data1, size1, data2, size2, out, max_out_size, seed);
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t *data,
+                                      std::size_t size) {
+  return proto_fuzzer::ProtoFuzzerTestOneInput(kProfile, data, size);
+}

--- a/ossconfig/curl_fuzzer_proto_gopher.options
+++ b/ossconfig/curl_fuzzer_proto_gopher.options
@@ -1,0 +1,2 @@
+[libfuzzer]
+max_len = 32768

--- a/proto_fuzzer/multi_transfer_runner.cc
+++ b/proto_fuzzer/multi_transfer_runner.cc
@@ -195,7 +195,8 @@ MultiTransferRunStats MultiTransferRunner::Run(const curl::fuzzer::proto::Scenar
     if (!transfer.easy) {
       continue;
     }
-    transfer.connect_to.reset(ApplyBaselineOptions(transfer.easy.get(), curl::fuzzer::proto::SCHEME_HTTP));
+    transfer.connect_to.reset(ApplyBaselineOptions(transfer.easy.get(), curl::fuzzer::proto::SCHEME_HTTP,
+                                                   scenario.trace_ids()));
     (void)curl_easy_setopt(transfer.easy.get(), CURLOPT_URL, url.c_str());
     mock.Install(transfer.easy.get());
     (void)ApplyScenarioOptions(transfer.easy.get(), scenario);

--- a/proto_fuzzer/multi_transfer_runner.cc
+++ b/proto_fuzzer/multi_transfer_runner.cc
@@ -46,8 +46,8 @@ std::size_t RuntimeTransferCount(const curl::fuzzer::proto::MultiPlan& plan) {
                   std::min(static_cast<std::size_t>(plan.transfer_count()), scenario_limits::kMaxMultiTransfers));
 }
 
-void RecordNotification(CURLM *, unsigned int notification, CURL *, void *userdata) {
-  auto *stats = static_cast<MultiTransferRunStats *>(userdata);
+void RecordNotification(CURLM*, unsigned int notification, CURL*, void* userdata) {
+  auto* stats = static_cast<MultiTransferRunStats*>(userdata);
   if (stats == nullptr) {
     return;
   }
@@ -179,8 +179,7 @@ MultiTransferRunStats MultiTransferRunner::Run(const curl::fuzzer::proto::Scenar
   (void)curl_multi_setopt(multi.get(), CURLMOPT_MAXCONNECTS, cache_size);
   (void)curl_multi_setopt(multi.get(), CURLMOPT_PIPELINING,
                           plan.multiplex() ? static_cast<long>(CURLPIPE_MULTIPLEX) : 0L);
-  (void)curl_multi_setopt(multi.get(), CURLMOPT_NOTIFYFUNCTION,
-                          &RecordNotification);
+  (void)curl_multi_setopt(multi.get(), CURLMOPT_NOTIFYFUNCTION, &RecordNotification);
   (void)curl_multi_setopt(multi.get(), CURLMOPT_NOTIFYDATA, &stats);
   (void)curl_multi_notify_enable(multi.get(), CURLMNOTIFY_INFO_READ);
   (void)curl_multi_notify_enable(multi.get(), CURLMNOTIFY_EASY_DONE);
@@ -195,8 +194,8 @@ MultiTransferRunStats MultiTransferRunner::Run(const curl::fuzzer::proto::Scenar
     if (!transfer.easy) {
       continue;
     }
-    transfer.connect_to.reset(ApplyBaselineOptions(transfer.easy.get(), curl::fuzzer::proto::SCHEME_HTTP,
-                                                   scenario.trace_ids()));
+    transfer.connect_to.reset(
+        ApplyBaselineOptions(transfer.easy.get(), curl::fuzzer::proto::SCHEME_HTTP, scenario.trace_ids()));
     (void)curl_easy_setopt(transfer.easy.get(), CURLOPT_URL, url.c_str());
     mock.Install(transfer.easy.get());
     (void)ApplyScenarioOptions(transfer.easy.get(), scenario);

--- a/proto_fuzzer/multi_transfer_runner.cc
+++ b/proto_fuzzer/multi_transfer_runner.cc
@@ -46,6 +46,18 @@ std::size_t RuntimeTransferCount(const curl::fuzzer::proto::MultiPlan& plan) {
                   std::min(static_cast<std::size_t>(plan.transfer_count()), scenario_limits::kMaxMultiTransfers));
 }
 
+void RecordNotification(CURLM *, unsigned int notification, CURL *, void *userdata) {
+  auto *stats = static_cast<MultiTransferRunStats *>(userdata);
+  if (stats == nullptr) {
+    return;
+  }
+  if (notification == CURLMNOTIFY_INFO_READ) {
+    ++stats->info_read_notifications;
+  } else if (notification == CURLMNOTIFY_EASY_DONE) {
+    ++stats->easy_done_notifications;
+  }
+}
+
 /// Consume every currently queued completion before handle removal can discard
 /// it. Re-added handles may complete more than once, so count messages rather
 /// than only distinct easy pointers.
@@ -167,6 +179,11 @@ MultiTransferRunStats MultiTransferRunner::Run(const curl::fuzzer::proto::Scenar
   (void)curl_multi_setopt(multi.get(), CURLMOPT_MAXCONNECTS, cache_size);
   (void)curl_multi_setopt(multi.get(), CURLMOPT_PIPELINING,
                           plan.multiplex() ? static_cast<long>(CURLPIPE_MULTIPLEX) : 0L);
+  (void)curl_multi_setopt(multi.get(), CURLMOPT_NOTIFYFUNCTION,
+                          &RecordNotification);
+  (void)curl_multi_setopt(multi.get(), CURLMOPT_NOTIFYDATA, &stats);
+  (void)curl_multi_notify_enable(multi.get(), CURLMNOTIFY_INFO_READ);
+  (void)curl_multi_notify_enable(multi.get(), CURLMNOTIFY_EASY_DONE);
 
   const bool socket_mode = plan.drive_mode() == curl::fuzzer::proto::MULTI_DRIVE_SOCKET;
   const bool socket_driver_installed = socket_mode && socket_driver.Install(multi.get());

--- a/proto_fuzzer/multi_transfer_runner.h
+++ b/proto_fuzzer/multi_transfer_runner.h
@@ -25,6 +25,10 @@ struct MultiTransferRunStats {
   std::size_t added_handles = 0;
   /// CURLMSG_DONE records consumed across all configured handles.
   std::size_t completion_messages = 0;
+  /// CURLMNOTIFY_INFO_READ notifications dispatched to the multi handle.
+  std::size_t info_read_notifications = 0;
+  /// CURLMNOTIFY_EASY_DONE notifications dispatched to the multi handle.
+  std::size_t easy_done_notifications = 0;
   /// Ordered plan actions consumed, including intentional no-ops.
   std::size_t actions_consumed = 0;
   /// Peer sockets opened while serving the concurrent transfers.

--- a/proto_fuzzer/option_apply.cc
+++ b/proto_fuzzer/option_apply.cc
@@ -194,8 +194,7 @@ void CanonicalizeOptionValueCases(curl::fuzzer::proto::Scenario* scenario) {
 /// @param scheme Protocol whose dedicated in-process mock will service it.
 /// @return the curl_slist owned by the caller (for CURLOPT_CONNECT_TO), which
 ///         must be freed with curl_slist_free_all after curl_easy_cleanup.
-struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme,
-                                         bool trace_ids) {
+struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme, bool trace_ids) {
   EnableDebugHttpTransportMetadata();
 
   curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, &SilentWriteCallback);
@@ -232,6 +231,12 @@ struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme 
       break;
     case curl::fuzzer::proto::SCHEME_TFTP:
       direct_protocols = kTftpProtocolAllowed;
+      break;
+    case curl::fuzzer::proto::SCHEME_GOPHER:
+      direct_protocols = "gopher";
+      break;
+    case curl::fuzzer::proto::SCHEME_GOPHERS:
+      direct_protocols = "gophers";
       break;
     case curl::fuzzer::proto::SCHEME_HTTP:
     case curl::fuzzer::proto::SCHEME_HTTPS:

--- a/proto_fuzzer/option_apply.cc
+++ b/proto_fuzzer/option_apply.cc
@@ -104,6 +104,11 @@ void EnableDebugHttpTransportMetadata() {
   (void)configured;
 }
 
+void EnableTraceIds() {
+  static const bool enabled = curl_global_trace("+LIB-IDS") == CURLE_OK;
+  (void)enabled;
+}
+
 /// Decode protobuf's two integral oneof members according to the semantic
 /// kind in the generated option descriptor. The schema cannot couple an
 /// option id to one particular oneof member, so both retained corpus entries
@@ -189,14 +194,21 @@ void CanonicalizeOptionValueCases(curl::fuzzer::proto::Scenario* scenario) {
 /// @param scheme Protocol whose dedicated in-process mock will service it.
 /// @return the curl_slist owned by the caller (for CURLOPT_CONNECT_TO), which
 ///         must be freed with curl_slist_free_all after curl_easy_cleanup.
-struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme) {
+struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme,
+                                         bool trace_ids) {
   EnableDebugHttpTransportMetadata();
 
   curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, &SilentWriteCallback);
   curl_easy_setopt(easy, CURLOPT_HEADERFUNCTION, &SilentWriteCallback);
 
   const bool user_requested_verbose = std::getenv(kVerboseEnvVar) != nullptr;
-  if (scheme == curl::fuzzer::proto::SCHEME_TELNET && !user_requested_verbose) {
+  if (trace_ids) {
+    EnableTraceIds();
+    // Keep trace-ID coverage enabled during fuzzing without flooding the
+    // process log. The callback still executes curl_trc.c's formatting path.
+    curl_easy_setopt(easy, CURLOPT_DEBUGFUNCTION, &SilentDebugCallback);
+    curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+  } else if (scheme == curl::fuzzer::proto::SCHEME_TELNET && !user_requested_verbose) {
     // printoption() and printsub() contain a substantial part of curl's TELNET
     // parser diagnostics but run only in verbose mode. Keep those paths in the
     // ordinary TELNET coverage lane while suppressing their high-volume text.

--- a/proto_fuzzer/option_apply.h
+++ b/proto_fuzzer/option_apply.h
@@ -42,8 +42,8 @@ void CanonicalizeOptionValueCases(curl::fuzzer::proto::Scenario* scenario);
 /// Returns a caller-owned CONNECT_TO list that must outlive the easy handle.
 /// `scheme` identifies the dedicated in-process mock that will service the
 /// transfer and therefore selects the safe direct-protocol allowlist.
-struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme,
-                                        bool trace_ids = false);
+/// @param trace_ids Enable verbose LIB-IDS tracing for this scenario.
+struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme, bool trace_ids = false);
 
 /// Translate and apply one generated scalar/string option. String pointers
 /// borrow the SetOption's protobuf-owned storage, so the containing Scenario

--- a/proto_fuzzer/option_apply.h
+++ b/proto_fuzzer/option_apply.h
@@ -42,7 +42,8 @@ void CanonicalizeOptionValueCases(curl::fuzzer::proto::Scenario* scenario);
 /// Returns a caller-owned CONNECT_TO list that must outlive the easy handle.
 /// `scheme` identifies the dedicated in-process mock that will service the
 /// transfer and therefore selects the safe direct-protocol allowlist.
-struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme);
+struct curl_slist* ApplyBaselineOptions(CURL* easy, curl::fuzzer::proto::Scheme scheme,
+                                        bool trace_ids = false);
 
 /// Translate and apply one generated scalar/string option. String pointers
 /// borrow the SetOption's protobuf-owned storage, so the containing Scenario

--- a/proto_fuzzer/scenario_runner.cc
+++ b/proto_fuzzer/scenario_runner.cc
@@ -94,6 +94,10 @@ const char* SchemePrefix(curl::fuzzer::proto::Scheme scheme) {
       return "ftp";
     case curl::fuzzer::proto::SCHEME_TFTP:
       return "tftp";
+    case curl::fuzzer::proto::SCHEME_GOPHER:
+      return "gopher";
+    case curl::fuzzer::proto::SCHEME_GOPHERS:
+      return "gophers";
     case curl::fuzzer::proto::SCHEME_UNSPECIFIED:
     default:
       return nullptr;
@@ -138,6 +142,17 @@ std::unique_ptr<MockServerBase> MakeMockServerForScenario(const curl::fuzzer::pr
       (void)mode;
 #endif
       return std::make_unique<MockServer>();
+    case curl::fuzzer::proto::SCHEME_GOPHER:
+      return mode == ScenarioRunMode::kGopherCoverage ? std::make_unique<MockServer>() : nullptr;
+    case curl::fuzzer::proto::SCHEME_GOPHERS:
+#if defined(PROTO_FUZZER_HAS_TLS_MOCK_SERVER)
+      if (mode == ScenarioRunMode::kGopherCoverage) {
+        return std::make_unique<TlsMockServer>(scenario.tls_certificate_chain());
+      }
+      return nullptr;
+#else
+      return nullptr;
+#endif
     case curl::fuzzer::proto::SCHEME_WS:
     case curl::fuzzer::proto::SCHEME_WSS:
       return std::make_unique<WebSocketMockServer>();

--- a/proto_fuzzer/scenario_runner.cc
+++ b/proto_fuzzer/scenario_runner.cc
@@ -211,7 +211,7 @@ int ScenarioRunner::Run(const curl::fuzzer::proto::Scenario& scenario, ScenarioR
 
   std::string url = std::string(prefix) + "://" + scenario.host_path();
   const auto configure_easy = [&] {
-    connect_to.reset(ApplyBaselineOptions(easy.get(), scenario.scheme()));
+    connect_to.reset(ApplyBaselineOptions(easy.get(), scenario.scheme(), scenario.trace_ids()));
     curl_easy_setopt(easy.get(), CURLOPT_URL, url.c_str());
     mock->Install(easy.get());
 

--- a/proto_fuzzer/target_policy.cc
+++ b/proto_fuzzer/target_policy.cc
@@ -960,6 +960,17 @@ void RemoveIgnoredTftpShape(curl::fuzzer::proto::Scenario* scenario) {
   RemoveUnusedFileTransferConnectionShape(scenario->mutable_connection());
 }
 
+void RemoveIgnoredGopherShape(curl::fuzzer::proto::Scenario* scenario) {
+  scenario->clear_subsequent_connections();
+  scenario->clear_request_headers();
+  scenario->clear_mime_post();
+  scenario->clear_upload();
+  RemoveTelnetOnlyShape(scenario);
+  RemoveApiOnlyShape(scenario);
+  RemoveMultiOnlyShape(scenario);
+  RemoveUnusedFileTransferConnectionShape(scenario->mutable_connection());
+}
+
 /// Preserve useful in-range mutations while folding ineffective extremes onto
 /// meaningful boundaries. Zero remains special: it disables that individual
 /// control and lets the other control provide the timing target's pressure.
@@ -1121,6 +1132,17 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
     return;
   }
 
+  if (profile == TargetProfile::kFastGopher) {
+    scenario->set_scheme(scenario->scheme() == curl::fuzzer::proto::SCHEME_GOPHERS
+                             ? curl::fuzzer::proto::SCHEME_GOPHERS
+                             : curl::fuzzer::proto::SCHEME_GOPHER);
+    RemoveIgnoredGopherShape(scenario);
+    RemoveFileTransferOnlyOptions(scenario);
+    BoundScenarioShape(scenario);
+    CanonicalizeTlsAuthority(scenario);
+    return;
+  }
+
   // Select the lane's scheme before applying scheme-sensitive upload bounds.
   // The scheme field is itself mutable, so bounding first could accidentally
   // give an HTTP/WS case TELNET's smaller payload budget merely because that
@@ -1241,6 +1263,7 @@ void ApplyTargetPolicy(curl::fuzzer::proto::Scenario* scenario, TargetProfile pr
 
     case TargetProfile::kFastFtp:
     case TargetProfile::kFastTftp:
+    case TargetProfile::kFastGopher:
       // Their peers consume narrower raw-script shapes, pruned before general
       // bounds so ignored fields never tax these fast paths.
       return;

--- a/proto_fuzzer/target_profile.h
+++ b/proto_fuzzer/target_profile.h
@@ -38,6 +38,8 @@ enum class TargetProfile {
   kFastFtp,
   /// Exercise packet-preserving TFTP exchanges over the loopback UDP peer.
   kFastTftp,
+  /// Exercise Gopher selectors through the bounded stream peer.
+  kFastGopher,
   /// Exercise easy, share, multi, URL, and result API lifecycles.
   kApi,
   /// Exercise several easy handles through one shared multi handle.
@@ -63,6 +65,8 @@ enum class ScenarioRunMode {
   kFtpCoverage,
   /// Drive TFTP through its datagram-preserving loopback peer.
   kTftpCoverage,
+  /// Drive Gopher through the bounded stream peer.
+  kGopherCoverage,
   /// Honour ApiPlan and run the dedicated lifecycle and typed-result probes.
   kApiLifecycle,
   /// Honour MultiPlan and drive several HTTP transfers through one multi.
@@ -100,6 +104,9 @@ constexpr ScenarioRunMode RunModeFor(TargetProfile profile) {
 
     case TargetProfile::kFastTftp:
       return ScenarioRunMode::kTftpCoverage;
+
+    case TargetProfile::kFastGopher:
+      return ScenarioRunMode::kGopherCoverage;
 
     case TargetProfile::kCompatibility:
     case TargetProfile::kDeepHttp:

--- a/scenarios/curl_fuzzer_proto/gopher/gopher_menu_listing.textproto
+++ b/scenarios/curl_fuzzer_proto/gopher/gopher_menu_listing.textproto
@@ -1,0 +1,5 @@
+scheme: SCHEME_GOPHER
+host_path: "tls.test/1/menu"
+connection {
+  initial_response: "0Example\t/menu\ttls.test\t70\r\n.\r\n"
+}

--- a/scenarios/curl_fuzzer_proto/gopher/gophers_tls_menu.textproto
+++ b/scenarios/curl_fuzzer_proto/gopher/gophers_tls_menu.textproto
@@ -1,0 +1,5 @@
+scheme: SCHEME_GOPHERS
+host_path: "tls.test/1/secure"
+connection {
+  initial_response: "0Secure\t/\ttls.test\t70\r\n.\r\n"
+}

--- a/scenarios/curl_fuzzer_proto/multi/multi_trace_ids.textproto
+++ b/scenarios/curl_fuzzer_proto/multi/multi_trace_ids.textproto
@@ -1,0 +1,12 @@
+scheme: SCHEME_HTTP
+host_path: "multi.test/trace-ids"
+connection {
+  initial_response: "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok"
+}
+trace_ids: true
+multi_plan {
+  transfer_count: 2
+  max_host_connections: 2
+  max_total_connections: 2
+  connection_cache_size: 2
+}

--- a/schemas/curl_fuzzer.proto
+++ b/schemas/curl_fuzzer.proto
@@ -369,6 +369,8 @@ enum Scheme {
   // Scenarios accumulated before these dedicated lanes existed.
   SCHEME_FTP = 6;
   SCHEME_TFTP = 7;
+  SCHEME_GOPHER = 8;
+  SCHEME_GOPHERS = 9;
 }
 
 message SetOption {

--- a/schemas/curl_fuzzer.proto
+++ b/schemas/curl_fuzzer.proto
@@ -84,6 +84,8 @@ message Scenario {
   // onto the appropriate QUIC streams. Non-H3 fixed targets discard the plan;
   // the compatibility target deliberately leaves field 13 untouched.
   Http3Plan http3_plan = 13;
+  // Enable verbose curl tracing with LIB-IDS prefixes for this scenario.
+  bool trace_ids = 14;
 }
 
 // Test-only certificate bundles available to the in-process TLS server. Zero

--- a/scripts/fuzz_targets
+++ b/scripts/fuzz_targets
@@ -4,7 +4,7 @@ FUZZ_TARGETS_LIST="curl_fuzzer_dict curl_fuzzer_file curl_fuzzer_ftp curl_fuzzer
 
 # The structured fuzzer is 64-bit only.
 if [ "${ARCHITECTURE:-}" != "i386" ]; then
-    FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto curl_fuzzer_proto_http curl_fuzzer_proto_http_deep curl_fuzzer_proto_https curl_fuzzer_proto_h2_proxy curl_fuzzer_proto_ws curl_fuzzer_proto_wss curl_fuzzer_proto_telnet curl_fuzzer_proto_ftp curl_fuzzer_proto_tftp curl_fuzzer_proto_api curl_fuzzer_proto_multi curl_fuzzer_proto_timing"
+    FUZZ_TARGETS_LIST="${FUZZ_TARGETS_LIST} curl_fuzzer_proto curl_fuzzer_proto_http curl_fuzzer_proto_http_deep curl_fuzzer_proto_https curl_fuzzer_proto_h2_proxy curl_fuzzer_proto_ws curl_fuzzer_proto_wss curl_fuzzer_proto_telnet curl_fuzzer_proto_ftp curl_fuzzer_proto_tftp curl_fuzzer_proto_gopher curl_fuzzer_proto_api curl_fuzzer_proto_multi curl_fuzzer_proto_timing"
     # The alternative TLS dependency stacks are intentionally omitted from
     # MemorySanitizer until all of their static dependencies can be built with
     # MSan instrumentation.

--- a/tests/multi_transfer_runner_test.cc
+++ b/tests/multi_transfer_runner_test.cc
@@ -6,6 +6,8 @@
 
 #include "proto_fuzzer/multi_transfer_runner.h"
 
+#include <curl/curl.h>
+
 #include <cstddef>
 #include <cstdlib>
 #include <iostream>
@@ -53,6 +55,28 @@ void TestCompletesConcurrentHandles() {
          "multi runner did not attach every configured easy handle");
   Expect(stats.completion_messages == 3,
          "multi runner did not consume every concurrent completion");
+  Expect(stats.info_read_notifications > 0,
+         "multi runner did not dispatch INFO_READ notifications");
+  Expect(stats.easy_done_notifications > 0,
+         "multi runner did not dispatch EASY_DONE notifications");
+}
+
+void TestNotificationTypeValidation() {
+  CURLM *multi = curl_multi_init();
+  Expect(multi != nullptr, "could not create multi handle");
+
+  Expect(curl_multi_notify_enable(multi, CURLMNOTIFY_INFO_READ) == CURLM_OK,
+         "valid notification enable failed");
+  Expect(curl_multi_notify_disable(multi, CURLMNOTIFY_INFO_READ) == CURLM_OK,
+         "valid notification disable failed");
+  Expect(curl_multi_notify_enable(multi, CURLMNOTIFY_LAST) ==
+             CURLM_UNKNOWN_OPTION,
+         "invalid notification enable was accepted");
+  Expect(curl_multi_notify_disable(multi, CURLMNOTIFY_LAST) ==
+             CURLM_UNKNOWN_OPTION,
+         "invalid notification disable was accepted");
+
+  curl_multi_cleanup(multi);
 }
 
 void TestQueuesAndReusesOneConnection() {
@@ -109,6 +133,7 @@ void TestConsumesBoundedActions() {
 
 int main() {
   TestCompletesConcurrentHandles();
+  TestNotificationTypeValidation();
   TestQueuesAndReusesOneConnection();
   TestConsumesBoundedActions();
   return 0;

--- a/tests/test_fuzzer_entrypoints.py
+++ b/tests/test_fuzzer_entrypoints.py
@@ -36,6 +36,7 @@ PROTO_TARGET_PROFILES = {
     "curl_fuzzer_proto_telnet": "kFastTelnet",
     "curl_fuzzer_proto_ftp": "kFastFtp",
     "curl_fuzzer_proto_tftp": "kFastTftp",
+    "curl_fuzzer_proto_gopher": "kFastGopher",
     "curl_fuzzer_proto_api": "kApi",
     "curl_fuzzer_proto_multi": "kMulti",
     "curl_fuzzer_proto_timing": "kTiming",


### PR DESCRIPTION
This pull request adds comprehensive fuzzing support for the Gopher protocol to the curl fuzzer suite, along with improvements to trace ID coverage and multi-transfer statistics. The most significant changes include enabling Gopher protocol fuzzing, introducing new scenario files, updating protocol coverage logic, and adding trace ID support to scenarios and statistics collection.

**Gopher protocol fuzzing support:**
- Added a dedicated Gopher protocol fuzzer entrypoint (`curl_fuzzer_proto_gopher.cc`), CMake integration, and scenario corpora for both plain Gopher and Gophers (TLS) protocols. [[1]](diffhunk://#diff-84a5af903facded7c4471463fcc27a49fe963611943a8a6e27c22f0c9755e852R1-R36) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR499) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1486) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1513-R1514) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1667-R1668) [[6]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR1700) [[7]](diffhunk://#diff-19e3f275f557ea8a41aa3b84ca699a47a4ea621054cf1d9efec8b4b8457d842fR1-R2) [[8]](diffhunk://#diff-00f409281554c521b15180664c59400d7cbff76e54002df76aeea79f66bf4943R1-R5) [[9]](diffhunk://#diff-9b08e4dc09f525d9ce393d9685244554dd60045301742615b68168c25c3b3d75R1-R5)
- Updated protocol allowlists, scheme handling, and mock server logic to support Gopher and Gophers in scenario runners and option application. [[1]](diffhunk://#diff-7eebdcf998a0f1fb4d5b06ac47d2c6608079b602118cde06b5ef34c6c67a852bR236-R241) [[2]](diffhunk://#diff-12619284cdd5f3ed63849bd0db6fa7e667072b87983e036adc76885b71079395R97-R100) [[3]](diffhunk://#diff-12619284cdd5f3ed63849bd0db6fa7e667072b87983e036adc76885b71079395R145-R155)

**Target profile and scenario logic:**
- Introduced `kFastGopher` target profile and `kGopherCoverage` scenario run mode, with corresponding policy and scenario shape pruning logic. [[1]](diffhunk://#diff-2f29e583bf99ebe095816515d9b1ebcc3e89f23ae7be9f0ea196313cb860a6e0R41-R42) [[2]](diffhunk://#diff-2f29e583bf99ebe095816515d9b1ebcc3e89f23ae7be9f0ea196313cb860a6e0R68-R69) [[3]](diffhunk://#diff-2f29e583bf99ebe095816515d9b1ebcc3e89f23ae7be9f0ea196313cb860a6e0R108-R110) [[4]](diffhunk://#diff-52c1abe4fe5be732bd3e6490588ae1db55aa18044188be61dbe801f17ffbdc0fR1135-R1145) [[5]](diffhunk://#diff-52c1abe4fe5be732bd3e6490588ae1db55aa18044188be61dbe801f17ffbdc0fR1266) F71d0c8fL104R104)

**Trace ID and verbose tracing improvements:**
- Added a `trace_ids` boolean field to the `Scenario` proto and implemented logic to enable verbose LIB-IDS-prefixed curl tracing for scenarios that request it. [[1]](diffhunk://#diff-71b87fd296c7abbbb2fed15f603d376f1d9d87f9def1eb7788ce70a9ad7971a1R87-R88) [[2]](diffhunk://#diff-7eebdcf998a0f1fb4d5b06ac47d2c6608079b602118cde06b5ef34c6c67a852bL192-R211) [[3]](diffhunk://#diff-12619284cdd5f3ed63849bd0db6fa7e667072b87983e036adc76885b71079395L214-R229) [[4]](diffhunk://#diff-ab6cc4f72445642d268e693b51a0e0ce9d81492514836c6dbb270e256e9faaedR1-R12)

**Multi-transfer statistics and notifications:**
- Added new statistics to track `CURLMNOTIFY_INFO_READ` and `CURLMNOTIFY_EASY_DONE` notifications in multi-transfer fuzzing runs, including notification callback and CMake integration. [[1]](diffhunk://#diff-35df11de322e3880a957a6405ea472f884948b3961b329d8e32f2615eb63926cR49-R60) [[2]](diffhunk://#diff-35df11de322e3880a957a6405ea472f884948b3961b329d8e32f2615eb63926cR182-R186) [[3]](diffhunk://#diff-74c74c40c04b5cf6dff527aeda86067195b910b0c287f0fc1a4c96ac050fbbc6R28-R31)

**General improvements and maintenance:**
- Updated default arguments and function signatures to support new features and maintain backward compatibility.

These changes significantly expand protocol coverage in the fuzzing suite and improve observability and configurability for advanced protocol testing.